### PR TITLE
build(docker): use project version as docker image tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,13 +28,6 @@ jobs:
           java-version: 11
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
-      - name: Set environment variable RELEASE_VERSION to SNAPSHOT
-        run: |
-          echo "RELEASE_VERSION=snapshot" >> $GITHUB_ENV
-      - name: Set environment variable RELEASE_VERSION to the GitHub Release (Release only)
-        if: github.event.release
-        run: |
-          echo "RELEASE_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       - name: Login to Docker
         run: |
           # new login with new container registry url and PAT

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                 <configuration>
                     <to>
                         <image>ghcr.io/camunda-community-hub/zeebe-simple-monitor</image>
-                        <tags>${dockerTags}</tags>
+                        <tags>${project.version}</tags>
                     </to>
                     <container>
                         <ports>
@@ -310,30 +310,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>snapshot</id>
-            <activation>
-                <property>
-                    <name>RELEASE_VERSION</name>
-                    <value>snapshot</value>
-                </property>
-            </activation>
-            <properties>
-                <dockerTags>${project.version}</dockerTags>
-            </properties>
-        </profile>
-        <profile>
-            <id>release</id>
-            <activation>
-                <property>
-                    <name>RELEASE_VERSION</name>
-                    <value>!snapshot</value>
-                </property>
-            </activation>
-            <properties>
-                <dockerTags>latest,${project.version}</dockerTags>
-            </properties>
-        </profile>
     </profiles>
 
     <repositories>


### PR DESCRIPTION
Simplify the build/deploy process by using the project version as the docker image tag. 
Avoid tagging the docker image as `latest` because it seems not recommended. 