### PR TITLE
Fix broken error page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,12 +169,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- hot swapping, live reload -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,19 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.2</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- hot swapping, live reload -->
@@ -274,6 +287,12 @@
                     <overWriteReleases>false</overWriteReleases>
                     <overWriteSnapshots>true</overWriteSnapshots>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
             </plugin>
 
         </plugins>

--- a/src/main/java/io/zeebe/monitor/rest/ExceptionHandler.java
+++ b/src/main/java/io/zeebe/monitor/rest/ExceptionHandler.java
@@ -1,0 +1,53 @@
+package io.zeebe.monitor.rest;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@ControllerAdvice
+public class ExceptionHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ExceptionHandler.class);
+
+	private final String basePath;
+	private final String logoPath;
+	private final String customCssPath;
+	private final String customJsPath;
+	private final String customTitle;
+
+
+	public ExceptionHandler(@Value("${server.servlet.context-path}") final String basePath,
+	                        @Value("${white-label.logo.path}") final String logoPath,
+	                        @Value("${white-label.custom.title}") final String customTitle,
+	                        @Value("${white-label.custom.css.path}") final String customCssPath,
+	                        @Value("${white-label.custom.js.path}") final String customJsPath) {
+		this.basePath = basePath.endsWith("/") ? basePath : basePath + "/";
+		this.logoPath = logoPath;
+		this.customTitle = customTitle;
+		this.customCssPath = customCssPath;
+		this.customJsPath = customJsPath;
+
+	}
+
+	@org.springframework.web.bind.annotation.ExceptionHandler(RuntimeException.class)
+	public String handleRuntimeException(RuntimeException exc, final Model model) {
+		LOG.error(exc.getMessage(), exc);
+
+		model.addAttribute("status", exc.getClass().getSimpleName());
+		model.addAttribute("error", exc.getMessage());
+		model.addAttribute("message", exc.getMessage());
+		model.addAttribute("trace", ExceptionUtils.getStackTrace(exc));
+
+		model.addAttribute("custom-title", customTitle);
+		model.addAttribute("context-path", basePath);
+		model.addAttribute("logo-path", logoPath);
+		model.addAttribute("custom-css-path", customCssPath);
+		model.addAttribute("custom-js-path", customJsPath);
+
+		return "error";
+	}
+
+}

--- a/src/main/java/io/zeebe/monitor/rest/ViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ViewController.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import javax.transaction.Transactional;
@@ -99,7 +100,6 @@ public class ViewController {
 
   @GetMapping("/")
   public String index(final Map<String, Object> model, final Pageable pageable) {
-    addCommonVariablesToModel(model);
     return processList(model, pageable);
   }
 
@@ -117,7 +117,6 @@ public class ViewController {
     model.put("processes", processes);
     model.put("count", count);
 
-    addCommonVariablesToModel(model);
     addPaginationToModel(model, pageable, count);
 
     return "process-list-view";
@@ -180,7 +179,6 @@ public class ViewController {
     final var bpmn = Bpmn.readModelFromStream(resourceAsStream);
     model.put("instance.bpmnElementInfos", getBpmnElementInfos(bpmn));
 
-    addCommonVariablesToModel(model);
     addPaginationToModel(model, pageable, count);
 
     return "process-detail-view";
@@ -256,7 +254,6 @@ public class ViewController {
     model.put("instances", instances);
     model.put("count", count);
 
-    addCommonVariablesToModel(model);
     addPaginationToModel(model, pageable, count);
 
     return "instance-list-view";
@@ -277,8 +274,6 @@ public class ViewController {
         .ifPresent(process -> model.put("resource", getProcessResource(process)));
 
     model.put("instance", toInstanceDto(instance));
-
-    addCommonVariablesToModel(model);
 
     return "instance-detail-view";
   }
@@ -680,7 +675,6 @@ public class ViewController {
     model.put("incidents", incidents);
     model.put("count", count);
 
-    addCommonVariablesToModel(model);
     addPaginationToModel(model, pageable, count);
 
     return "incident-list-view";
@@ -727,7 +721,6 @@ public class ViewController {
     model.put("jobs", dtos);
     model.put("count", count);
 
-    addCommonVariablesToModel(model);
     addPaginationToModel(model, pageable, count);
 
     return "job-list-view";
@@ -762,7 +755,6 @@ public class ViewController {
     model.put("messages", dtos);
     model.put("count", count);
 
-    addCommonVariablesToModel(model);
     addPaginationToModel(model, pageable, count);
 
     return "message-list-view";
@@ -782,7 +774,6 @@ public class ViewController {
     model.put("errors", dtos);
     model.put("count", count);
 
-    addCommonVariablesToModel(model);
     addPaginationToModel(model, pageable, count);
 
     return "error-list-view";
@@ -858,21 +849,30 @@ public class ViewController {
     return resource.replaceAll("`", "\"");
   }
 
-  private void addCommonVariablesToModel(final Map<String, Object> model) {
-    addContextPathToModel(model);
-    addWhitelabelingOptionsToModel(model);
-  }
+    @ModelAttribute("context-path")
+    public String getBasePath() {
+        return basePath;
+    }
 
-  private void addContextPathToModel(final Map<String, Object> model) {
-    model.put("context-path", basePath);
-  }
+    @ModelAttribute("logo-path")
+    public String getLogoPath() {
+        return logoPath;
+    }
 
-  private void addWhitelabelingOptionsToModel(final Map<String, Object> model) {
-    model.put("logo-path", logoPath);
-    model.put("custom-css-path", customCssPath);
-    model.put("custom-js-path", customJsPath);
-    model.put("custom-title", customTitle);
-  }
+    @ModelAttribute("custom-css-path")
+    public String getCustomCssPath() {
+        return customCssPath;
+    }
+
+    @ModelAttribute("custom-js-path")
+    public String getCustomJsPath() {
+        return customJsPath;
+    }
+
+    @ModelAttribute("custom-title")
+    public String getCustomTitle() {
+        return customTitle;
+    }
 
   private void addPaginationToModel(
       final Map<String, Object> model, final Pageable pageable, final long count) {

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -8,7 +8,7 @@
             <p>{{message}}</p>
             <hr>
             <pre>
-{{trace}}
+                {{trace}}
             </pre>
         </div>
 

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -4,10 +4,12 @@
     <div class="col-md-12">
 
         <div class="alert alert-danger" role="alert">
-            <h4 class="alert-heading">Error {{status}} - {{error}}</h4>
+            <h4 class="alert-heading">{{status}}</h4>
             <p>{{message}}</p>
             <hr>
-            <p class="mb-0" style="white-space: pre-line;">{{trace}}</p>
+            <pre>
+{{trace}}
+            </pre>
         </div>
 
     </div>

--- a/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
@@ -26,8 +26,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {
@@ -72,37 +71,47 @@ public class ViewControllerTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    when(processRepository.findAll(any(Pageable.class))).thenReturn(Page.empty());
+	  when(processRepository.findAll(any(Pageable.class))).thenReturn(Page.empty());
   }
 
-  @Test
-  public void index_page_successfully_responded() throws Exception {
-    mockMvc.perform(get("/"))
-            .andExpect(status().isOk());
-  }
+	@Test
+	public void index_page_successfully_responded() throws Exception {
+		mockMvc.perform(get("/"))
+				.andExpect(status().isOk());
+	}
 
-  @Test
-  public void index_page_contains_whitelabeling_title() throws Exception {
-    mockMvc.perform(get("/"))
-            .andExpect(content().string(containsString("Test Zeebe Simple Monitor")));
-  }
+	@Test
+	public void index_page_contains_whitelabeling_title() throws Exception {
+		mockMvc.perform(get("/"))
+				.andExpect(content().string(containsString("Test Zeebe Simple Monitor")));
+	}
 
-  @Test
-  public void index_page_contains_whitelabeling_logo() throws Exception {
-    mockMvc.perform(get("/"))
-            .andExpect(content().string(containsString("<img src=\"/img/test-logo.png\"")));
-  }
+	@Test
+	public void index_page_contains_whitelabeling_logo() throws Exception {
+		mockMvc.perform(get("/"))
+				.andExpect(content().string(containsString("<img src=\"/img/test-logo.png\"")));
+	}
 
-  @Test
-  public void index_page_contains_whitelabeling_js() throws Exception {
-    mockMvc.perform(get("/"))
-            .andExpect(content().string(containsString("<script src=\"/js/test-custom.js\"")));
+	@Test
+	public void index_page_contains_whitelabeling_js() throws Exception {
+		mockMvc.perform(get("/"))
+				.andExpect(content().string(containsString("<script src=\"/js/test-custom.js\"")));
 
-  }
+	}
 
-  @Test
-  public void index_page_contains_whitelabeling_css() throws Exception {
-    mockMvc.perform(get("/"))
-            .andExpect(content().string(containsString("<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/test-custom.css\"/>")));
-  }
+	@Test
+	public void index_page_contains_whitelabeling_css() throws Exception {
+		mockMvc.perform(get("/"))
+				.andExpect(content().string(containsString("<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/test-custom.css\"/>")));
+	}
+
+	@Test
+	public void testModelAttributesContextPathIsPresent() throws Exception {
+		mockMvc.perform(get("/"))
+				.andExpect(model().attributeExists("context-path"))
+				.andExpect(model().attributeExists("logo-path"))
+				.andExpect(model().attributeExists("custom-css-path"))
+				.andExpect(model().attributeExists("custom-js-path"))
+				.andExpect(model().attributeExists("custom-title"));
+	}
 }

--- a/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
@@ -1,47 +1,49 @@
 package io.zeebe.monitor.rest;
 
-import io.zeebe.monitor.ZeebeSimpleMonitorApp;
-import io.zeebe.monitor.repository.*;
+import io.zeebe.monitor.repository.ElementInstanceRepository;
+import io.zeebe.monitor.repository.ErrorRepository;
+import io.zeebe.monitor.repository.HazelcastConfigRepository;
+import io.zeebe.monitor.repository.IncidentRepository;
+import io.zeebe.monitor.repository.JobRepository;
+import io.zeebe.monitor.repository.MessageRepository;
+import io.zeebe.monitor.repository.MessageSubscriptionRepository;
+import io.zeebe.monitor.repository.ProcessInstanceRepository;
+import io.zeebe.monitor.repository.ProcessRepository;
+import io.zeebe.monitor.repository.TimerRepository;
+import io.zeebe.monitor.repository.VariableRepository;
 import io.zeebe.monitor.zeebe.ZeebeHazelcastService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "white-label.logo.path: img/test-logo.png",
+                "white-label.custom.title: Test Zeebe Simple Monitor",
+                "white-label.custom.css.path: css/test-custom.css",
+                "white-label.custom.js.path: js/test-custom.js",
+        })
 @AutoConfigureMockMvc
-@SpringBootTest(classes = ZeebeSimpleMonitorApp.class,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-        "white-label.logo.path: img/test-logo.png",
-        "white-label.custom.title: Test Zeebe Simple Monitor",
-        "white-label.custom.css.path: css/test-custom.css",
-        "white-label.custom.js.path: js/test-custom.js",
-    })
 public class ViewControllerTest {
-
-  @LocalServerPort
-  private int port;
 
   @Autowired
   private ViewController controller;
 
   @Autowired
-  private TestRestTemplate restTemplate;
+  private MockMvc mockMvc;
 
   @MockBean
   private HazelcastConfigRepository hazelcastConfigRepository;
@@ -68,44 +70,39 @@ public class ViewControllerTest {
   @MockBean
   private ErrorRepository errorRepository;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     when(processRepository.findAll(any(Pageable.class))).thenReturn(Page.empty());
   }
 
   @Test
-  public void index_page_successfully_responded() {
-    ResponseEntity<String> entity = restTemplate.getForEntity("/", String.class);
-
-    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+  public void index_page_successfully_responded() throws Exception {
+    mockMvc.perform(get("/"))
+            .andExpect(status().isOk());
   }
 
   @Test
-  public void index_page_contains_whitelabeling_title() {
-    ResponseEntity<String> entity = restTemplate.getForEntity("/", String.class);
-
-    assertThat(entity.getBody()).contains("Test Zeebe Simple Monitor");
+  public void index_page_contains_whitelabeling_title() throws Exception {
+    mockMvc.perform(get("/"))
+            .andExpect(content().string(containsString("Test Zeebe Simple Monitor")));
   }
 
   @Test
-  public void index_page_contains_whitelabeling_logo() {
-    ResponseEntity<String> entity = restTemplate.getForEntity("/", String.class);
-
-    assertThat(entity.getBody()).contains("<img src=\"/img/test-logo.png\"");
+  public void index_page_contains_whitelabeling_logo() throws Exception {
+    mockMvc.perform(get("/"))
+            .andExpect(content().string(containsString("<img src=\"/img/test-logo.png\"")));
   }
 
   @Test
-  public void index_page_contains_whitelabeling_js() {
-    ResponseEntity<String> entity = restTemplate.getForEntity("/", String.class);
+  public void index_page_contains_whitelabeling_js() throws Exception {
+    mockMvc.perform(get("/"))
+            .andExpect(content().string(containsString("<script src=\"/js/test-custom.js\"")));
 
-    assertThat(entity.getBody()).contains("<script src=\"/js/test-custom.js\"></script>");
   }
 
   @Test
-  public void index_page_contains_whitelabeling_css() {
-    ResponseEntity<String> entity = restTemplate.getForEntity("/", String.class);
-
-    assertThat(entity.getBody()).contains("<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/test-custom.css\"/>");
+  public void index_page_contains_whitelabeling_css() throws Exception {
+    mockMvc.perform(get("/"))
+            .andExpect(content().string(containsString("<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/test-custom.css\"/>")));
   }
-
 }


### PR DESCRIPTION
Hi!
We'd like to use Zeebe Simple Monitor to track some processes.

With the knowledge from https://github.com/camunda-community-hub/zeebe-simple-monitor/issues/237 in mind, we've stumbled upon incomplete entities. This could lead to some Exceptions here and there, e.g. at

    public String instanceDetail(
        @PathVariable final long key, final Map<String, Object> model, final Pageable pageable) {

      final ProcessInstanceEntity instance =
          processInstanceRepository
              .findByKey(key)
              .orElseThrow(() -> new RuntimeException("No process instance found with key: " + key));
    ...

if `findByKey(key)` returns null, the `RuntimeException` is thrown. There are other places that assumes certain entities to be present, 

Spring will forward us to the `error.html` template, which imports `header.html` and `footer.html`. Unfortunately, these templates rely on attributes like `context-path`, which has not been set, yet.

So I'd suggest:
- use `@ModelAttribute` to populate these attributes independent of the code
- implement an `@ExceptionHandler` that is able to provide the attributes to the template
- update `error.html` slightly (AFAICS it was not in use, yet),
- additionally migrate the newly created `ViewControllerTest` to JUnit5 and to MockMVC for easier testing of Spring features.

Please see the updated files in this PR. I hope it's good enough to be accepted. If not I'll update it.

(It would be even better to prevent `RuntimeException` at all, but that's a even deeper refactoring.)