### PR TITLE
Fix for #278 Bug: Variables and ElementInstances not stored in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The application imports the data from Zeebe using the [Hazelcast exporter](https
 
 ![how-it-works](docs/how-it-works.png)
 
-## Install
+## Upgrading from prior version
+
+See [upgrade instructions](./UPGRADE.md)
+
+## Fresh install
 
 ### Docker
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,32 @@
+
+Upgrade documentation for Zeebe Simple Monitor 
+==================================================
+
+## Upgrading from v2.0.0
+
+Due to some issues with storing variables and element instances, the database structure changed.
+Zeebe Simple Monitor will not alter existing database tables automatically, but if you have a PostgreSQL
+or other DB running, you need to alter the table structures manually, in order to keep your data.
+
+Of course, if you use an in-memory DB or do not need to keep prior data, then simply drop all tables and sequences,
+and let Zeebe Simple Monitor create them again for you (automatic creation works).
+
+### Upgrade procedure
+
+1. stop Zeebe Simple Monitor (v2.0.0)
+2. run the SQL script below against your PostgreSQL Database
+3. start up Zeebe Simple Monitor (new version)
+
+```sql
+-- part 1, element_instance table changes
+ALTER TABLE element_instance DROP CONSTRAINT element_instance_pkey;
+ALTER TABLE element_instance ADD COLUMN ID SERIAL NOT NULL CONSTRAINT element_instance_pkey PRIMARY KEY;
+CREATE INDEX element_instance_processInstanceKeyIndex ON element_instance (process_instance_key_);
+-- part 2, variable table changes
+ALTER TABLE variable DROP CONSTRAINT variable_pkey;
+ALTER TABLE variable ADD COLUMN ID SERIAL NOT NULL CONSTRAINT variable_pkey PRIMARY KEY;
+ALTER TABLE variable ADD COLUMN PARTITION_ID_ integer DEFAULT 0;
+CREATE INDEX variable_processInstanceKeyIndex ON variable (process_instance_key_);
+```
+(This SQL script uses some recent PostgreSQL features, like 'SERIAL'.
+ You might need to adopt that if you're using another Database)

--- a/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
@@ -15,14 +15,20 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity(name = "ELEMENT_INSTANCE")
+@Table(indexes = {
+    // performance reason, because we use it in the ElementInstanceRepository.findByProcessInstanceKey()
+    @Index(name = "element_instance_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class ElementInstanceEntity {
 
   @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  @Column(name = "ID")
+  private long id;
+
   @Column(name = "POSITION_")
   private Long position;
 
@@ -52,6 +58,14 @@ public class ElementInstanceEntity {
 
   @Column(name = "TIMESTAMP_")
   private long timestamp;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(final long id) {
+    this.id = id;
+  }
 
   public long getKey() {
     return key;

--- a/src/main/java/io/zeebe/monitor/entity/VariableEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/VariableEntity.java
@@ -15,17 +15,25 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
+import javax.persistence.*;
 
 @Entity(name = "VARIABLE")
+@Table(indexes = {
+    // performance reason, because we use it in the VariableRepository.findByProcessInstanceKey()
+    @Index(name = "variable_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class VariableEntity {
 
   @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  @Column(name = "ID")
+  private long id;
+
   @Column(name = "POSITION_")
   private Long position;
+
+  @Column(name = "PARTITION_ID_")
+  private int partitionId;
 
   @Column(name = "NAME_")
   private String name;
@@ -45,6 +53,14 @@ public class VariableEntity {
 
   @Column(name = "TIMESTAMP_")
   private long timestamp;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(final long id) {
+    this.id = id;
+  }
 
   public String getState() {
     return state;
@@ -100,5 +116,13 @@ public class VariableEntity {
 
   public void setPosition(final Long position) {
     this.position = position;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/ZeebeImportService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/ZeebeImportService.java
@@ -1,61 +1,28 @@
 package io.zeebe.monitor.zeebe;
 
 import com.hazelcast.core.HazelcastInstance;
-import io.camunda.zeebe.protocol.Protocol;
-import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.intent.MessageIntent;
-import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
-import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.hazelcast.connect.java.ZeebeHazelcast;
-import io.zeebe.monitor.entity.ElementInstanceEntity;
-import io.zeebe.monitor.entity.ErrorEntity;
 import io.zeebe.monitor.entity.HazelcastConfig;
-import io.zeebe.monitor.entity.IncidentEntity;
-import io.zeebe.monitor.entity.JobEntity;
-import io.zeebe.monitor.entity.MessageEntity;
-import io.zeebe.monitor.entity.MessageSubscriptionEntity;
-import io.zeebe.monitor.entity.ProcessEntity;
-import io.zeebe.monitor.entity.ProcessInstanceEntity;
-import io.zeebe.monitor.entity.TimerEntity;
-import io.zeebe.monitor.entity.VariableEntity;
-import io.zeebe.monitor.repository.ElementInstanceRepository;
-import io.zeebe.monitor.repository.ErrorRepository;
 import io.zeebe.monitor.repository.HazelcastConfigRepository;
-import io.zeebe.monitor.repository.IncidentRepository;
-import io.zeebe.monitor.repository.JobRepository;
-import io.zeebe.monitor.repository.MessageRepository;
-import io.zeebe.monitor.repository.MessageSubscriptionRepository;
-import io.zeebe.monitor.repository.ProcessInstanceRepository;
-import io.zeebe.monitor.repository.ProcessRepository;
-import io.zeebe.monitor.repository.TimerRepository;
-import io.zeebe.monitor.repository.VariableRepository;
+import io.zeebe.monitor.zeebe.importers.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 @Component
 public class ZeebeImportService {
 
-  @Autowired private ProcessRepository processRepository;
-  @Autowired private ProcessInstanceRepository processInstanceRepository;
-  @Autowired private ElementInstanceRepository elementInstanceRepository;
-  @Autowired private VariableRepository variableRepository;
-  @Autowired private JobRepository jobRepository;
-  @Autowired private IncidentRepository incidentRepository;
-  @Autowired private MessageRepository messageRepository;
-  @Autowired private MessageSubscriptionRepository messageSubscriptionRepository;
-  @Autowired private TimerRepository timerRepository;
-  @Autowired private ErrorRepository errorRepository;
-
-  @Autowired private ZeebeNotificationService notificationService;
+  @Autowired private ProcessAndElementImporter processAndElementImporter;
+  @Autowired private VariableImporter variableImporter;
+  @Autowired private JobImporter jobImporter;
+  @Autowired private IncidentImporter incidentImporter;
+  @Autowired private MessageImporter messageImporter;
+  @Autowired private MessageSubscriptionImporter messageSubscriptionImporter;
+  @Autowired private TimerImporter timerImporter;
+  @Autowired private ErrorImporter errorImporter;
 
   @Autowired private HazelcastConfigRepository hazelcastConfigRepository;
 
@@ -75,36 +42,36 @@ public class ZeebeImportService {
     final var builder =
         ZeebeHazelcast.newBuilder(hazelcast)
             .addProcessListener(
-                record -> ifEvent(record, Schema.ProcessRecord::getMetadata, this::importProcess))
+                record -> ifEvent(record, Schema.ProcessRecord::getMetadata, processAndElementImporter::importProcess))
             .addProcessInstanceListener(
                 record ->
                     ifEvent(
                         record,
                         Schema.ProcessInstanceRecord::getMetadata,
-                        this::importProcessInstance))
+                        processAndElementImporter::importProcessInstance))
             .addIncidentListener(
-                record -> ifEvent(record, Schema.IncidentRecord::getMetadata, this::importIncident))
+                record -> ifEvent(record, Schema.IncidentRecord::getMetadata, incidentImporter::importIncident))
             .addJobListener(
-                record -> ifEvent(record, Schema.JobRecord::getMetadata, this::importJob))
+                record -> ifEvent(record, Schema.JobRecord::getMetadata, jobImporter::importJob))
             .addVariableListener(
-                record -> ifEvent(record, Schema.VariableRecord::getMetadata, this::importVariable))
+                record -> ifEvent(record, Schema.VariableRecord::getMetadata, variableImporter::importVariable))
             .addTimerListener(
-                record -> ifEvent(record, Schema.TimerRecord::getMetadata, this::importTimer))
+                record -> ifEvent(record, Schema.TimerRecord::getMetadata, timerImporter::importTimer))
             .addMessageListener(
-                record -> ifEvent(record, Schema.MessageRecord::getMetadata, this::importMessage))
+                record -> ifEvent(record, Schema.MessageRecord::getMetadata, messageImporter::importMessage))
             .addMessageSubscriptionListener(
                 record ->
                     ifEvent(
                         record,
                         Schema.MessageSubscriptionRecord::getMetadata,
-                        this::importMessageSubscription))
+                            messageSubscriptionImporter::importMessageSubscription))
             .addMessageStartEventSubscriptionListener(
                 record ->
                     ifEvent(
                         record,
                         Schema.MessageStartEventSubscriptionRecord::getMetadata,
-                        this::importMessageStartEventSubscription))
-            .addErrorListener(this::importError)
+                            messageSubscriptionImporter::importMessageStartEventSubscription))
+            .addErrorListener(errorImporter::importError)
             .postProcessListener(
                 sequence -> {
                   hazelcastConfig.setSequence(sequence);
@@ -134,313 +101,4 @@ public class ZeebeImportService {
     return metadata.getRecordType() == Schema.RecordMetadata.RecordType.EVENT;
   }
 
-  private void importProcess(final Schema.ProcessRecord record) {
-    final int partitionId = record.getMetadata().getPartitionId();
-
-    if (partitionId != Protocol.DEPLOYMENT_PARTITION) {
-      // ignore process event on other partitions to avoid duplicates
-      return;
-    }
-
-    final ProcessEntity entity = new ProcessEntity();
-    entity.setKey(record.getProcessDefinitionKey());
-    entity.setBpmnProcessId(record.getBpmnProcessId());
-    entity.setVersion(record.getVersion());
-    entity.setResource(record.getResource().toStringUtf8());
-    entity.setTimestamp(record.getMetadata().getTimestamp());
-    processRepository.save(entity);
-  }
-
-  private void importProcessInstance(final Schema.ProcessInstanceRecord record) {
-    if (record.getProcessInstanceKey() == record.getMetadata().getKey()) {
-      addOrUpdateProcessInstance(record);
-    }
-
-    addElementInstance(record);
-  }
-
-  private void addOrUpdateProcessInstance(final Schema.ProcessInstanceRecord record) {
-
-    final Intent intent = ProcessInstanceIntent.valueOf(record.getMetadata().getIntent());
-    final long timestamp = record.getMetadata().getTimestamp();
-    final long processInstanceKey = record.getProcessInstanceKey();
-
-    final ProcessInstanceEntity entity =
-        processInstanceRepository
-            .findById(processInstanceKey)
-            .orElseGet(
-                () -> {
-                  final ProcessInstanceEntity newEntity = new ProcessInstanceEntity();
-                  newEntity.setPartitionId(record.getMetadata().getPartitionId());
-                  newEntity.setKey(processInstanceKey);
-                  newEntity.setBpmnProcessId(record.getBpmnProcessId());
-                  newEntity.setVersion(record.getVersion());
-                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-                  newEntity.setParentProcessInstanceKey(record.getParentProcessInstanceKey());
-                  newEntity.setParentElementInstanceKey(record.getParentElementInstanceKey());
-                  return newEntity;
-                });
-
-    if (intent == ProcessInstanceIntent.ELEMENT_ACTIVATED) {
-      entity.setState("Active");
-      entity.setStart(timestamp);
-      processInstanceRepository.save(entity);
-
-      notificationService.sendCreatedProcessInstance(
-          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
-
-    } else if (intent == ProcessInstanceIntent.ELEMENT_COMPLETED) {
-      entity.setState("Completed");
-      entity.setEnd(timestamp);
-      processInstanceRepository.save(entity);
-
-      notificationService.sendEndedProcessInstance(
-          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
-
-    } else if (intent == ProcessInstanceIntent.ELEMENT_TERMINATED) {
-      entity.setState("Terminated");
-      entity.setEnd(timestamp);
-      processInstanceRepository.save(entity);
-
-      notificationService.sendEndedProcessInstance(
-          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
-    }
-  }
-
-  private void addElementInstance(final Schema.ProcessInstanceRecord record) {
-
-    final long position = record.getMetadata().getPosition();
-    if (!elementInstanceRepository.existsById(position)) {
-
-      final ElementInstanceEntity entity = new ElementInstanceEntity();
-      entity.setPosition(position);
-      entity.setPartitionId(record.getMetadata().getPartitionId());
-      entity.setKey(record.getMetadata().getKey());
-      entity.setIntent(record.getMetadata().getIntent());
-      entity.setTimestamp(record.getMetadata().getTimestamp());
-      entity.setProcessInstanceKey(record.getProcessInstanceKey());
-      entity.setElementId(record.getElementId());
-      entity.setFlowScopeKey(record.getFlowScopeKey());
-      entity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-      entity.setBpmnElementType(record.getBpmnElementType());
-
-      elementInstanceRepository.save(entity);
-
-      notificationService.sendProcessInstanceUpdated(
-          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
-    }
-  }
-
-  private void importIncident(final Schema.IncidentRecord record) {
-
-    final IncidentIntent intent = IncidentIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
-
-    final IncidentEntity entity =
-        incidentRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final IncidentEntity newEntity = new IncidentEntity();
-                  newEntity.setKey(key);
-                  newEntity.setBpmnProcessId(record.getBpmnProcessId());
-                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  newEntity.setJobKey(record.getJobKey());
-                  newEntity.setErrorType(record.getErrorType());
-                  newEntity.setErrorMessage(record.getErrorMessage());
-                  return newEntity;
-                });
-
-    if (intent == IncidentIntent.CREATED) {
-      entity.setCreated(timestamp);
-      incidentRepository.save(entity);
-
-    } else if (intent == IncidentIntent.RESOLVED) {
-      entity.setResolved(timestamp);
-      incidentRepository.save(entity);
-    }
-  }
-
-  private void importJob(final Schema.JobRecord record) {
-
-    final JobIntent intent = JobIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
-
-    final JobEntity entity =
-        jobRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final JobEntity newEntity = new JobEntity();
-                  newEntity.setKey(key);
-                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  newEntity.setJobType(record.getType());
-                  return newEntity;
-                });
-
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    entity.setWorker(record.getWorker());
-    entity.setRetries(record.getRetries());
-    jobRepository.save(entity);
-  }
-
-  private void importMessage(final Schema.MessageRecord record) {
-
-    final MessageIntent intent = MessageIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
-
-    final MessageEntity entity =
-        messageRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final MessageEntity newEntity = new MessageEntity();
-                  newEntity.setKey(key);
-                  newEntity.setName(record.getName());
-                  newEntity.setCorrelationKey(record.getCorrelationKey());
-                  newEntity.setMessageId(record.getMessageId());
-                  newEntity.setPayload(record.getVariables().toString());
-                  return newEntity;
-                });
-
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    messageRepository.save(entity);
-  }
-
-  private void importMessageSubscription(final Schema.MessageSubscriptionRecord record) {
-
-    final MessageSubscriptionIntent intent =
-        MessageSubscriptionIntent.valueOf(record.getMetadata().getIntent());
-    final long timestamp = record.getMetadata().getTimestamp();
-
-    final MessageSubscriptionEntity entity =
-        messageSubscriptionRepository
-            .findByElementInstanceKeyAndMessageName(
-                record.getElementInstanceKey(), record.getMessageName())
-            .orElseGet(
-                () -> {
-                  final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
-                  newEntity.setId(
-                      generateId()); // message subscription doesn't have a key - it is always '-1'
-                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  newEntity.setMessageName(record.getMessageName());
-                  newEntity.setCorrelationKey(record.getCorrelationKey());
-                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                  return newEntity;
-                });
-
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    messageSubscriptionRepository.save(entity);
-  }
-
-  private void importMessageStartEventSubscription(
-      final Schema.MessageStartEventSubscriptionRecord record) {
-
-    final MessageStartEventSubscriptionIntent intent =
-        MessageStartEventSubscriptionIntent.valueOf(record.getMetadata().getIntent());
-    final long timestamp = record.getMetadata().getTimestamp();
-
-    final MessageSubscriptionEntity entity =
-        messageSubscriptionRepository
-            .findByProcessDefinitionKeyAndMessageName(
-                record.getProcessDefinitionKey(), record.getMessageName())
-            .orElseGet(
-                () -> {
-                  final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
-                  newEntity.setId(
-                      generateId()); // message subscription doesn't have a key - it is always '-1'
-                  newEntity.setMessageName(record.getMessageName());
-                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-                  newEntity.setTargetFlowNodeId(record.getStartEventId());
-                  return newEntity;
-                });
-
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    messageSubscriptionRepository.save(entity);
-  }
-
-  private void importTimer(final Schema.TimerRecord record) {
-
-    final TimerIntent intent = TimerIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
-
-    final TimerEntity entity =
-        timerRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final TimerEntity newEntity = new TimerEntity();
-                  newEntity.setKey(key);
-                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-                  newEntity.setTargetElementId(record.getTargetElementId());
-                  newEntity.setDueDate(record.getDueDate());
-                  newEntity.setRepetitions(record.getRepetitions());
-
-                  if (record.getProcessInstanceKey() > 0) {
-                    newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                    newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  }
-
-                  return newEntity;
-                });
-
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    timerRepository.save(entity);
-  }
-
-  private void importVariable(final Schema.VariableRecord record) {
-
-    final long position = record.getMetadata().getPosition();
-    if (!variableRepository.existsById(position)) {
-
-      final VariableEntity entity = new VariableEntity();
-      entity.setPosition(position);
-      entity.setTimestamp(record.getMetadata().getTimestamp());
-      entity.setProcessInstanceKey(record.getProcessInstanceKey());
-      entity.setName(record.getName());
-      entity.setValue(record.getValue());
-      entity.setScopeKey(record.getScopeKey());
-      entity.setState(record.getMetadata().getIntent().toLowerCase());
-      variableRepository.save(entity);
-    }
-  }
-
-  private void importError(final Schema.ErrorRecord record) {
-
-    final var metadata = record.getMetadata();
-    final var position = metadata.getPosition();
-
-    final var entity =
-        errorRepository
-            .findById(position)
-            .orElseGet(
-                () -> {
-                  final var newEntity = new ErrorEntity();
-                  newEntity.setPosition(position);
-                  newEntity.setErrorEventPosition(record.getErrorEventPosition());
-                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                  newEntity.setExceptionMessage(record.getExceptionMessage());
-                  newEntity.setStacktrace(record.getStacktrace());
-                  newEntity.setTimestamp(metadata.getTimestamp());
-                  return newEntity;
-                });
-
-    errorRepository.save(entity);
-  }
-
-  private String generateId() {
-    return UUID.randomUUID().toString();
-  }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/ErrorImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/ErrorImporter.java
@@ -1,0 +1,37 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.ErrorEntity;
+import io.zeebe.monitor.repository.ErrorRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ErrorImporter {
+
+  @Autowired private ErrorRepository errorRepository;
+
+  public void importError(final Schema.ErrorRecord record) {
+
+    final var metadata = record.getMetadata();
+    final var position = metadata.getPosition();
+
+    final var entity =
+        errorRepository
+            .findById(position)
+            .orElseGet(
+                () -> {
+                  final var newEntity = new ErrorEntity();
+                  newEntity.setPosition(position);
+                  newEntity.setErrorEventPosition(record.getErrorEventPosition());
+                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                  newEntity.setExceptionMessage(record.getExceptionMessage());
+                  newEntity.setStacktrace(record.getStacktrace());
+                  newEntity.setTimestamp(metadata.getTimestamp());
+                  return newEntity;
+                });
+
+    errorRepository.save(entity);
+  }
+
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/IncidentImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/IncidentImporter.java
@@ -1,0 +1,48 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.IncidentEntity;
+import io.zeebe.monitor.repository.IncidentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IncidentImporter {
+
+  @Autowired private IncidentRepository incidentRepository;
+
+  public void importIncident(final Schema.IncidentRecord record) {
+
+    final IncidentIntent intent = IncidentIntent.valueOf(record.getMetadata().getIntent());
+    final long key = record.getMetadata().getKey();
+    final long timestamp = record.getMetadata().getTimestamp();
+
+    final IncidentEntity entity =
+        incidentRepository
+            .findById(key)
+            .orElseGet(
+                () -> {
+                  final IncidentEntity newEntity = new IncidentEntity();
+                  newEntity.setKey(key);
+                  newEntity.setBpmnProcessId(record.getBpmnProcessId());
+                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                  newEntity.setJobKey(record.getJobKey());
+                  newEntity.setErrorType(record.getErrorType());
+                  newEntity.setErrorMessage(record.getErrorMessage());
+                  return newEntity;
+                });
+
+    if (intent == IncidentIntent.CREATED) {
+      entity.setCreated(timestamp);
+      incidentRepository.save(entity);
+
+    } else if (intent == IncidentIntent.RESOLVED) {
+      entity.setResolved(timestamp);
+      incidentRepository.save(entity);
+    }
+  }
+
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/JobImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/JobImporter.java
@@ -1,0 +1,41 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.JobEntity;
+import io.zeebe.monitor.repository.JobRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobImporter {
+
+  @Autowired private JobRepository jobRepository;
+
+  public void importJob(final Schema.JobRecord record) {
+
+    final JobIntent intent = JobIntent.valueOf(record.getMetadata().getIntent());
+    final long key = record.getMetadata().getKey();
+    final long timestamp = record.getMetadata().getTimestamp();
+
+    final JobEntity entity =
+        jobRepository
+            .findById(key)
+            .orElseGet(
+                () -> {
+                  final JobEntity newEntity = new JobEntity();
+                  newEntity.setKey(key);
+                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                  newEntity.setJobType(record.getType());
+                  return newEntity;
+                });
+
+    entity.setState(intent.name().toLowerCase());
+    entity.setTimestamp(timestamp);
+    entity.setWorker(record.getWorker());
+    entity.setRetries(record.getRetries());
+    jobRepository.save(entity);
+  }
+
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/MessageImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/MessageImporter.java
@@ -1,0 +1,39 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.MessageEntity;
+import io.zeebe.monitor.repository.MessageRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessageImporter {
+
+  @Autowired private MessageRepository messageRepository;
+
+  public void importMessage(final Schema.MessageRecord record) {
+
+    final MessageIntent intent = MessageIntent.valueOf(record.getMetadata().getIntent());
+    final long key = record.getMetadata().getKey();
+    final long timestamp = record.getMetadata().getTimestamp();
+
+    final MessageEntity entity =
+        messageRepository
+            .findById(key)
+            .orElseGet(
+                () -> {
+                  final MessageEntity newEntity = new MessageEntity();
+                  newEntity.setKey(key);
+                  newEntity.setName(record.getName());
+                  newEntity.setCorrelationKey(record.getCorrelationKey());
+                  newEntity.setMessageId(record.getMessageId());
+                  newEntity.setPayload(record.getVariables().toString());
+                  return newEntity;
+                });
+
+    entity.setState(intent.name().toLowerCase());
+    entity.setTimestamp(timestamp);
+    messageRepository.save(entity);
+  }
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/MessageSubscriptionImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/MessageSubscriptionImporter.java
@@ -1,0 +1,76 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.MessageSubscriptionEntity;
+import io.zeebe.monitor.repository.MessageSubscriptionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class MessageSubscriptionImporter {
+
+  @Autowired private MessageSubscriptionRepository messageSubscriptionRepository;
+
+  public void importMessageSubscription(final Schema.MessageSubscriptionRecord record) {
+
+    final MessageSubscriptionIntent intent =
+        MessageSubscriptionIntent.valueOf(record.getMetadata().getIntent());
+    final long timestamp = record.getMetadata().getTimestamp();
+
+    final MessageSubscriptionEntity entity =
+        messageSubscriptionRepository
+            .findByElementInstanceKeyAndMessageName(
+                record.getElementInstanceKey(), record.getMessageName())
+            .orElseGet(
+                () -> {
+                  final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
+                  newEntity.setId(
+                      generateId()); // message subscription doesn't have a key - it is always '-1'
+                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                  newEntity.setMessageName(record.getMessageName());
+                  newEntity.setCorrelationKey(record.getCorrelationKey());
+                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                  return newEntity;
+                });
+
+    entity.setState(intent.name().toLowerCase());
+    entity.setTimestamp(timestamp);
+    messageSubscriptionRepository.save(entity);
+  }
+
+  public void importMessageStartEventSubscription(
+      final Schema.MessageStartEventSubscriptionRecord record) {
+
+    final MessageStartEventSubscriptionIntent intent =
+        MessageStartEventSubscriptionIntent.valueOf(record.getMetadata().getIntent());
+    final long timestamp = record.getMetadata().getTimestamp();
+
+    final MessageSubscriptionEntity entity =
+        messageSubscriptionRepository
+            .findByProcessDefinitionKeyAndMessageName(
+                record.getProcessDefinitionKey(), record.getMessageName())
+            .orElseGet(
+                () -> {
+                  final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
+                  newEntity.setId(
+                      generateId()); // message subscription doesn't have a key - it is always '-1'
+                  newEntity.setMessageName(record.getMessageName());
+                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+                  newEntity.setTargetFlowNodeId(record.getStartEventId());
+                  return newEntity;
+                });
+
+    entity.setState(intent.name().toLowerCase());
+    entity.setTimestamp(timestamp);
+    messageSubscriptionRepository.save(entity);
+  }
+
+  private String generateId() {
+    return UUID.randomUUID().toString();
+  }
+
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporter.java
@@ -1,0 +1,123 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.ElementInstanceEntity;
+import io.zeebe.monitor.entity.ProcessEntity;
+import io.zeebe.monitor.entity.ProcessInstanceEntity;
+import io.zeebe.monitor.repository.ElementInstanceRepository;
+import io.zeebe.monitor.repository.ProcessInstanceRepository;
+import io.zeebe.monitor.repository.ProcessRepository;
+import io.zeebe.monitor.zeebe.ZeebeNotificationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessAndElementImporter {
+
+  @Autowired private ProcessRepository processRepository;
+  @Autowired private ProcessInstanceRepository processInstanceRepository;
+  @Autowired private ElementInstanceRepository elementInstanceRepository;
+
+  @Autowired private ZeebeNotificationService notificationService;
+
+  public void importProcess(final Schema.ProcessRecord record) {
+    final int partitionId = record.getMetadata().getPartitionId();
+
+    if (partitionId != Protocol.DEPLOYMENT_PARTITION) {
+      // ignore process event on other partitions to avoid duplicates
+      return;
+    }
+
+    final ProcessEntity entity = new ProcessEntity();
+    entity.setKey(record.getProcessDefinitionKey());
+    entity.setBpmnProcessId(record.getBpmnProcessId());
+    entity.setVersion(record.getVersion());
+    entity.setResource(record.getResource().toStringUtf8());
+    entity.setTimestamp(record.getMetadata().getTimestamp());
+    processRepository.save(entity);
+  }
+
+  public void importProcessInstance(final Schema.ProcessInstanceRecord record) {
+    if (record.getProcessInstanceKey() == record.getMetadata().getKey()) {
+      addOrUpdateProcessInstance(record);
+    }
+
+    addElementInstance(record);
+  }
+
+  private void addOrUpdateProcessInstance(final Schema.ProcessInstanceRecord record) {
+
+    final Intent intent = ProcessInstanceIntent.valueOf(record.getMetadata().getIntent());
+    final long timestamp = record.getMetadata().getTimestamp();
+    final long processInstanceKey = record.getProcessInstanceKey();
+
+    final ProcessInstanceEntity entity =
+        processInstanceRepository
+            .findById(processInstanceKey)
+            .orElseGet(
+                () -> {
+                  final ProcessInstanceEntity newEntity = new ProcessInstanceEntity();
+                  newEntity.setPartitionId(record.getMetadata().getPartitionId());
+                  newEntity.setKey(processInstanceKey);
+                  newEntity.setBpmnProcessId(record.getBpmnProcessId());
+                  newEntity.setVersion(record.getVersion());
+                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+                  newEntity.setParentProcessInstanceKey(record.getParentProcessInstanceKey());
+                  newEntity.setParentElementInstanceKey(record.getParentElementInstanceKey());
+                  return newEntity;
+                });
+
+    if (intent == ProcessInstanceIntent.ELEMENT_ACTIVATED) {
+      entity.setState("Active");
+      entity.setStart(timestamp);
+      processInstanceRepository.save(entity);
+
+      notificationService.sendCreatedProcessInstance(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+
+    } else if (intent == ProcessInstanceIntent.ELEMENT_COMPLETED) {
+      entity.setState("Completed");
+      entity.setEnd(timestamp);
+      processInstanceRepository.save(entity);
+
+      notificationService.sendEndedProcessInstance(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+
+    } else if (intent == ProcessInstanceIntent.ELEMENT_TERMINATED) {
+      entity.setState("Terminated");
+      entity.setEnd(timestamp);
+      processInstanceRepository.save(entity);
+
+      notificationService.sendEndedProcessInstance(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+    }
+  }
+
+  private void addElementInstance(final Schema.ProcessInstanceRecord record) {
+
+    final long position = record.getMetadata().getPosition();
+    if (!elementInstanceRepository.existsById(position)) {
+
+      final ElementInstanceEntity entity = new ElementInstanceEntity();
+      entity.setPosition(position);
+      entity.setPartitionId(record.getMetadata().getPartitionId());
+      entity.setKey(record.getMetadata().getKey());
+      entity.setIntent(record.getMetadata().getIntent());
+      entity.setTimestamp(record.getMetadata().getTimestamp());
+      entity.setProcessInstanceKey(record.getProcessInstanceKey());
+      entity.setElementId(record.getElementId());
+      entity.setFlowScopeKey(record.getFlowScopeKey());
+      entity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+      entity.setBpmnElementType(record.getBpmnElementType());
+
+      elementInstanceRepository.save(entity);
+
+      notificationService.sendProcessInstanceUpdated(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+    }
+  }
+
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporter.java
@@ -44,7 +44,6 @@ public class ProcessAndElementImporter {
     if (record.getProcessInstanceKey() == record.getMetadata().getKey()) {
       addOrUpdateProcessInstance(record);
     }
-
     addElementInstance(record);
   }
 
@@ -97,27 +96,19 @@ public class ProcessAndElementImporter {
   }
 
   private void addElementInstance(final Schema.ProcessInstanceRecord record) {
-
-    final long position = record.getMetadata().getPosition();
-    if (!elementInstanceRepository.existsById(position)) {
-
-      final ElementInstanceEntity entity = new ElementInstanceEntity();
-      entity.setPosition(position);
-      entity.setPartitionId(record.getMetadata().getPartitionId());
-      entity.setKey(record.getMetadata().getKey());
-      entity.setIntent(record.getMetadata().getIntent());
-      entity.setTimestamp(record.getMetadata().getTimestamp());
-      entity.setProcessInstanceKey(record.getProcessInstanceKey());
-      entity.setElementId(record.getElementId());
-      entity.setFlowScopeKey(record.getFlowScopeKey());
-      entity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-      entity.setBpmnElementType(record.getBpmnElementType());
-
-      elementInstanceRepository.save(entity);
-
-      notificationService.sendProcessInstanceUpdated(
-          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
-    }
+    final ElementInstanceEntity entity = new ElementInstanceEntity();
+    entity.setPosition(record.getMetadata().getPosition());
+    entity.setPartitionId(record.getMetadata().getPartitionId());
+    entity.setKey(record.getMetadata().getKey());
+    entity.setIntent(record.getMetadata().getIntent());
+    entity.setTimestamp(record.getMetadata().getTimestamp());
+    entity.setProcessInstanceKey(record.getProcessInstanceKey());
+    entity.setElementId(record.getElementId());
+    entity.setFlowScopeKey(record.getFlowScopeKey());
+    entity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+    entity.setBpmnElementType(record.getBpmnElementType());
+    elementInstanceRepository.save(entity);
+    notificationService.sendProcessInstanceUpdated(record.getProcessInstanceKey(), record.getProcessDefinitionKey());
   }
 
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/TimerImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/TimerImporter.java
@@ -1,0 +1,46 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.TimerEntity;
+import io.zeebe.monitor.repository.TimerRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimerImporter {
+
+  @Autowired private TimerRepository timerRepository;
+
+  public void importTimer(final Schema.TimerRecord record) {
+
+    final TimerIntent intent = TimerIntent.valueOf(record.getMetadata().getIntent());
+    final long key = record.getMetadata().getKey();
+    final long timestamp = record.getMetadata().getTimestamp();
+
+    final TimerEntity entity =
+        timerRepository
+            .findById(key)
+            .orElseGet(
+                () -> {
+                  final TimerEntity newEntity = new TimerEntity();
+                  newEntity.setKey(key);
+                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+                  newEntity.setTargetElementId(record.getTargetElementId());
+                  newEntity.setDueDate(record.getDueDate());
+                  newEntity.setRepetitions(record.getRepetitions());
+
+                  if (record.getProcessInstanceKey() > 0) {
+                    newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                    newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                  }
+
+                  return newEntity;
+                });
+
+    entity.setState(intent.name().toLowerCase());
+    entity.setTimestamp(timestamp);
+    timerRepository.save(entity);
+  }
+
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
@@ -1,0 +1,31 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.VariableEntity;
+import io.zeebe.monitor.repository.VariableRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VariableImporter {
+
+  @Autowired private VariableRepository variableRepository;
+
+  public void importVariable(final Schema.VariableRecord record) {
+
+    final long position = record.getMetadata().getPosition();
+    if (!variableRepository.existsById(position)) {
+
+      final VariableEntity entity = new VariableEntity();
+      entity.setPosition(position);
+      entity.setTimestamp(record.getMetadata().getTimestamp());
+      entity.setProcessInstanceKey(record.getProcessInstanceKey());
+      entity.setName(record.getName());
+      entity.setValue(record.getValue());
+      entity.setScopeKey(record.getScopeKey());
+      entity.setState(record.getMetadata().getIntent().toLowerCase());
+      variableRepository.save(entity);
+    }
+  }
+
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
@@ -12,20 +12,16 @@ public class VariableImporter {
   @Autowired private VariableRepository variableRepository;
 
   public void importVariable(final Schema.VariableRecord record) {
-
-    final long position = record.getMetadata().getPosition();
-    if (!variableRepository.existsById(position)) {
-
-      final VariableEntity entity = new VariableEntity();
-      entity.setPosition(position);
-      entity.setTimestamp(record.getMetadata().getTimestamp());
-      entity.setProcessInstanceKey(record.getProcessInstanceKey());
-      entity.setName(record.getName());
-      entity.setValue(record.getValue());
-      entity.setScopeKey(record.getScopeKey());
-      entity.setState(record.getMetadata().getIntent().toLowerCase());
-      variableRepository.save(entity);
-    }
+    final VariableEntity entity = new VariableEntity();
+    entity.setPosition(record.getMetadata().getPosition());
+    entity.setPartitionId(record.getMetadata().getPartitionId());
+    entity.setTimestamp(record.getMetadata().getTimestamp());
+    entity.setProcessInstanceKey(record.getProcessInstanceKey());
+    entity.setName(record.getName());
+    entity.setValue(record.getValue());
+    entity.setScopeKey(record.getScopeKey());
+    entity.setState(record.getMetadata().getIntent().toLowerCase());
+    variableRepository.save(entity);
   }
 
 }


### PR DESCRIPTION
The root cause was a broken check for duplicates in the DB.
This solution favors creating new ID unique index fields for the two mentioned tables,
in order to feed all data (variables and element_instances) into the DB.
Assuming, there are no duplicate events exported, there's no need for a duplicate check.

Additionally, two indices are added, for performance reasons.

Unfortunately, because JPA requires an @id field, a new field was introduced
and there's an UPGRADE instruction documented, so people out there would be able to migrate their installations.
In other words, this PR contains a breaking change in DB structures.

Also, if you look at what files are changed, this PR contains two commits.
The first one is pure refactoring, in order to split the ZeebeImportService class into multiple importer-classes.
This is mainly for readability. I hope you find this useful.
The second commit is the bug fix itself.

Any feedback is welcome.