### PR TITLE
bugfix for issue #278 - rework duplicate check element instances and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The application imports the data from Zeebe using the [Hazelcast exporter](https
 
 ![how-it-works](docs/how-it-works.png)
 
-## Install
+## Upgrading from prior version
+
+See [upgrade instructions](./UPGRADE.md)
+
+## Fresh install
 
 ### Docker
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,36 @@
+
+Upgrade documentation for Zeebe Simple Monitor 
+==================================================
+
+## Upgrading from v2.0.0
+
+Due to some issues with storing variables and element instances, the database structure changed.
+Zeebe Simple Monitor will not alter existing database tables automatically, but if you have a PostgreSQL
+or other DB running, you need to alter the table structures manually, in order to keep your data.
+
+Of course, if you use an in-memory DB or do not need to keep prior data, then simply drop all tables and sequences,
+and let Zeebe Simple Monitor create them again for you (automatic creation works).
+
+### Upgrade procedure
+
+1. stop Zeebe Simple Monitor (v2.0.0)
+2. run the SQL script below against your PostgreSQL Database
+3. start up Zeebe Simple Monitor (new version)
+
+```sql
+-- part 1, element_instance table changes
+ALTER TABLE element_instance ADD COLUMN ID varchar(255);
+UPDATE element_instance SET id = (partition_id_::varchar || '-' || position_::varchar) where true;
+ALTER TABLE element_instance DROP CONSTRAINT element_instance_pkey;
+ALTER TABLE element_instance ADD PRIMARY KEY (id);
+CREATE INDEX element_instance_processInstanceKeyIndex ON element_instance (process_instance_key_);
+-- part 2, variable table changes
+ALTER TABLE variable ADD COLUMN ID varchar(255);
+ALTER TABLE variable ADD COLUMN PARTITION_ID_ integer DEFAULT 1;
+UPDATE variable SET id = (partition_id_::varchar || '-' || position_::varchar) where true;
+ALTER TABLE variable DROP CONSTRAINT variable_pkey;
+ALTER TABLE variable ADD PRIMARY KEY (id);
+CREATE INDEX variable_processInstanceKeyIndex ON variable (process_instance_key_);
+```
+(This SQL was developed and tested using a recent PostgreSQL instance.
+ You might need to adopt that if you're using another Database)

--- a/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
@@ -15,14 +15,19 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity(name = "ELEMENT_INSTANCE")
+@Table(indexes = {
+    // performance reason, because we use it in the ElementInstanceRepository.findByProcessInstanceKey()
+    @Index(name = "element_instance_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class ElementInstanceEntity {
 
   @Id
+  @Column(name = "ID")
+  private String id;
+
   @Column(name = "POSITION_")
   private Long position;
 
@@ -52,6 +57,24 @@ public class ElementInstanceEntity {
 
   @Column(name = "TIMESTAMP_")
   private long timestamp;
+
+  public String getId() {
+    return id;
+  }
+
+  private void setId(final String id) {
+    // made private, to avoid accidental changes
+    this.id = id;
+  }
+
+  public final String getGeneratedIdentifier() {
+    return this.partitionId + "-" + this.position;
+  }
+
+  @PrePersist
+  private void prePersistDeriveIdField() {
+    setId(getGeneratedIdentifier());
+  }
 
   public long getKey() {
     return key;

--- a/src/main/java/io/zeebe/monitor/entity/VariableEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/VariableEntity.java
@@ -15,17 +15,24 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
+import javax.persistence.*;
 
 @Entity(name = "VARIABLE")
+@Table(indexes = {
+    // performance reason, because we use it in the VariableRepository.findByProcessInstanceKey()
+    @Index(name = "variable_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class VariableEntity {
 
   @Id
+  @Column(name = "ID")
+  private String id;
+
   @Column(name = "POSITION_")
   private Long position;
+
+  @Column(name = "PARTITION_ID_")
+  private int partitionId;
 
   @Column(name = "NAME_")
   private String name;
@@ -45,6 +52,24 @@ public class VariableEntity {
 
   @Column(name = "TIMESTAMP_")
   private long timestamp;
+
+  public String getId() {
+    return id;
+  }
+
+  private void setId(final String id) {
+    // made private, to avoid accidental changes
+    this.id = id;
+  }
+
+  public final String getGeneratedIdentifier() {
+    return this.partitionId + "-" + this.position;
+  }
+
+  @PrePersist
+  private void prePersistDeriveIdField(){
+    setId(getGeneratedIdentifier());
+  }
 
   public String getState() {
     return state;
@@ -100,5 +125,13 @@ public class VariableEntity {
 
   public void setPosition(final Long position) {
     this.position = position;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
   }
 }

--- a/src/main/java/io/zeebe/monitor/repository/ElementInstanceRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/ElementInstanceRepository.java
@@ -18,7 +18,7 @@ package io.zeebe.monitor.repository;
 import io.zeebe.monitor.entity.ElementInstanceEntity;
 import org.springframework.data.repository.CrudRepository;
 
-public interface ElementInstanceRepository extends CrudRepository<ElementInstanceEntity, Long> {
+public interface ElementInstanceRepository extends CrudRepository<ElementInstanceEntity, String> {
 
   Iterable<ElementInstanceEntity> findByProcessInstanceKey(long processInstanceKey);
 }

--- a/src/main/java/io/zeebe/monitor/repository/VariableRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/VariableRepository.java
@@ -20,7 +20,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.List;
 
-public interface VariableRepository extends PagingAndSortingRepository<VariableEntity, Long> {
+public interface VariableRepository extends PagingAndSortingRepository<VariableEntity, String> {
 
   List<VariableEntity> findByProcessInstanceKey(long processInstanceKey);
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporter.java
@@ -17,11 +17,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProcessAndElementImporter {
 
-  @Autowired private ProcessRepository processRepository;
-  @Autowired private ProcessInstanceRepository processInstanceRepository;
-  @Autowired private ElementInstanceRepository elementInstanceRepository;
+  @Autowired
+  private ProcessRepository processRepository;
+  @Autowired
+  private ProcessInstanceRepository processInstanceRepository;
+  @Autowired
+  private ElementInstanceRepository elementInstanceRepository;
 
-  @Autowired private ZeebeNotificationService notificationService;
+  @Autowired
+  private ZeebeNotificationService notificationService;
 
   public void importProcess(final Schema.ProcessRecord record) {
     final int partitionId = record.getMetadata().getPartitionId();
@@ -44,7 +48,6 @@ public class ProcessAndElementImporter {
     if (record.getProcessInstanceKey() == record.getMetadata().getKey()) {
       addOrUpdateProcessInstance(record);
     }
-
     addElementInstance(record);
   }
 
@@ -97,13 +100,10 @@ public class ProcessAndElementImporter {
   }
 
   private void addElementInstance(final Schema.ProcessInstanceRecord record) {
-
-    final long position = record.getMetadata().getPosition();
-    if (!elementInstanceRepository.existsById(position)) {
-
-      final ElementInstanceEntity entity = new ElementInstanceEntity();
-      entity.setPosition(position);
-      entity.setPartitionId(record.getMetadata().getPartitionId());
+    final ElementInstanceEntity entity = new ElementInstanceEntity();
+    entity.setPartitionId(record.getMetadata().getPartitionId());
+    entity.setPosition(record.getMetadata().getPosition());
+    if (!elementInstanceRepository.existsById(entity.getGeneratedIdentifier())) {
       entity.setKey(record.getMetadata().getKey());
       entity.setIntent(record.getMetadata().getIntent());
       entity.setTimestamp(record.getMetadata().getTimestamp());
@@ -112,11 +112,8 @@ public class ProcessAndElementImporter {
       entity.setFlowScopeKey(record.getFlowScopeKey());
       entity.setProcessDefinitionKey(record.getProcessDefinitionKey());
       entity.setBpmnElementType(record.getBpmnElementType());
-
       elementInstanceRepository.save(entity);
-
-      notificationService.sendProcessInstanceUpdated(
-          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+      notificationService.sendProcessInstanceUpdated(record.getProcessInstanceKey(), record.getProcessDefinitionKey());
     }
   }
 

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
@@ -9,22 +9,21 @@ import org.springframework.stereotype.Component;
 @Component
 public class VariableImporter {
 
-  @Autowired private VariableRepository variableRepository;
+  @Autowired
+  private VariableRepository variableRepository;
 
   public void importVariable(final Schema.VariableRecord record) {
-
-    final long position = record.getMetadata().getPosition();
-    if (!variableRepository.existsById(position)) {
-
-      final VariableEntity entity = new VariableEntity();
-      entity.setPosition(position);
-      entity.setTimestamp(record.getMetadata().getTimestamp());
-      entity.setProcessInstanceKey(record.getProcessInstanceKey());
-      entity.setName(record.getName());
-      entity.setValue(record.getValue());
-      entity.setScopeKey(record.getScopeKey());
-      entity.setState(record.getMetadata().getIntent().toLowerCase());
-      variableRepository.save(entity);
+    final VariableEntity newVariable = new VariableEntity();
+    newVariable.setPosition(record.getMetadata().getPosition());
+    newVariable.setPartitionId(record.getMetadata().getPartitionId());
+    if (!variableRepository.existsById(newVariable.getGeneratedIdentifier())) {
+      newVariable.setTimestamp(record.getMetadata().getTimestamp());
+      newVariable.setProcessInstanceKey(record.getProcessInstanceKey());
+      newVariable.setName(record.getName());
+      newVariable.setValue(record.getValue());
+      newVariable.setScopeKey(record.getScopeKey());
+      newVariable.setState(record.getMetadata().getIntent().toLowerCase());
+      variableRepository.save(newVariable);
     }
   }
 

--- a/src/test/java/io/zeebe/monitor/repository/ElementInstanceRepositoryTest.java
+++ b/src/test/java/io/zeebe/monitor/repository/ElementInstanceRepositoryTest.java
@@ -1,7 +1,7 @@
 package io.zeebe.monitor.repository;
 
 import io.zeebe.monitor.entity.ElementInstanceEntity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;

--- a/src/test/java/io/zeebe/monitor/repository/ElementInstanceRepositoryTest.java
+++ b/src/test/java/io/zeebe/monitor/repository/ElementInstanceRepositoryTest.java
@@ -1,0 +1,48 @@
+package io.zeebe.monitor.repository;
+
+import io.zeebe.monitor.entity.ElementInstanceEntity;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElementInstanceRepositoryTest extends ZeebeRepositoryTest {
+
+  @Autowired
+  private ElementInstanceRepository elementInstanceRepository;
+
+  @Test
+  public void JPA_will_automatically_update_the_ID_attribute() {
+    // given
+    ElementInstanceEntity elementInstance = createElementInstance();
+
+    // when
+    elementInstanceRepository.save(elementInstance);
+
+    // then
+    assertThat(elementInstance.getId()).isEqualTo("123-456");
+  }
+
+  @Test
+  public void variable_can_be_retrieved_by_transient_ID() {
+    // given
+    ElementInstanceEntity elementInstance = createElementInstance();
+
+    // when
+    elementInstanceRepository.save(elementInstance);
+
+    // then
+    Optional<ElementInstanceEntity> entity = elementInstanceRepository.findById("123-456");
+    assertThat(entity).isPresent();
+  }
+
+  private ElementInstanceEntity createElementInstance() {
+    ElementInstanceEntity elementInstance = new ElementInstanceEntity();
+    elementInstance.setPartitionId(123);
+    elementInstance.setPosition(456L);
+    return elementInstance;
+  }
+
+}

--- a/src/test/java/io/zeebe/monitor/repository/TestContextJpaConfiguration.java
+++ b/src/test/java/io/zeebe/monitor/repository/TestContextJpaConfiguration.java
@@ -1,0 +1,60 @@
+package io.zeebe.monitor.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.Properties;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "io.zeebe.monitor.repository")
+@EnableTransactionManagement
+public class TestContextJpaConfiguration {
+
+  @Bean
+  public DataSource dataSource() {
+    DriverManagerDataSource dataSource = new DriverManagerDataSource();
+    dataSource.setDriverClassName("org.h2.Driver");
+    dataSource.setUrl("jdbc:h2:mem:zeebe-monitor-test;DB_CLOSE_DELAY=-1");
+    dataSource.setUsername("sa");
+    dataSource.setPassword("");
+    return dataSource;
+  }
+
+  @Bean
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory(@Autowired DataSource dataSource) {
+    LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+    em.setDataSource(dataSource);
+    em.setPackagesToScan("io.zeebe.monitor.entity");
+
+    JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+    em.setJpaVendorAdapter(vendorAdapter);
+    em.setJpaProperties(getAdditionalJpaProperties());
+
+    return em;
+  }
+
+  @Bean
+  public PlatformTransactionManager transactionManager(@Autowired LocalContainerEntityManagerFactoryBean entityManagerFactory) {
+    JpaTransactionManager transactionManager = new JpaTransactionManager();
+    transactionManager.setEntityManagerFactory(entityManagerFactory.getObject());
+    return transactionManager;
+  }
+
+  private Properties getAdditionalJpaProperties() {
+    Properties p = new Properties();
+    p.setProperty("database-platform", "org.hibernate.dialect.H2Dialect");
+    p.setProperty("hibernate.hbm2ddl.auto", "update");
+    return p;
+  }
+
+}

--- a/src/test/java/io/zeebe/monitor/repository/VariableRepositoryTest.java
+++ b/src/test/java/io/zeebe/monitor/repository/VariableRepositoryTest.java
@@ -1,7 +1,7 @@
 package io.zeebe.monitor.repository;
 
 import io.zeebe.monitor.entity.VariableEntity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;

--- a/src/test/java/io/zeebe/monitor/repository/VariableRepositoryTest.java
+++ b/src/test/java/io/zeebe/monitor/repository/VariableRepositoryTest.java
@@ -1,0 +1,48 @@
+package io.zeebe.monitor.repository;
+
+import io.zeebe.monitor.entity.VariableEntity;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VariableRepositoryTest extends ZeebeRepositoryTest {
+
+  @Autowired
+  private VariableRepository variableRepository;
+
+  @Test
+  public void JPA_will_automatically_update_the_ID_attribute() {
+    // given
+    VariableEntity variable = createVariable();
+
+    // when
+    variableRepository.save(variable);
+
+    // then
+    assertThat(variable.getId()).isEqualTo("123-456");
+  }
+
+  @Test
+  public void variable_can_be_retrieved_by_transient_ID() {
+    // given
+    VariableEntity variable = createVariable();
+
+    // when
+    variableRepository.save(variable);
+
+    // then
+    Optional<VariableEntity> entity = variableRepository.findById("123-456");
+    assertThat(entity).isPresent();
+  }
+
+  private VariableEntity createVariable() {
+    VariableEntity variable = new VariableEntity();
+    variable.setPartitionId(123);
+    variable.setPosition(456L);
+    return variable;
+  }
+
+}

--- a/src/test/java/io/zeebe/monitor/repository/ZeebeRepositoryTest.java
+++ b/src/test/java/io/zeebe/monitor/repository/ZeebeRepositoryTest.java
@@ -1,0 +1,18 @@
+package io.zeebe.monitor.repository;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+    classes = {TestContextJpaConfiguration.class},
+    loader = AnnotationConfigContextLoader.class)
+@Transactional
+@ActiveProfiles("junittest")
+public abstract class ZeebeRepositoryTest {
+  // all Repository Tests should inherit from this one...
+}

--- a/src/test/java/io/zeebe/monitor/repository/ZeebeRepositoryTest.java
+++ b/src/test/java/io/zeebe/monitor/repository/ZeebeRepositoryTest.java
@@ -1,13 +1,12 @@
 package io.zeebe.monitor.repository;
 
-import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.transaction.annotation.Transactional;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
 @ContextConfiguration(
     classes = {TestContextJpaConfiguration.class},
     loader = AnnotationConfigContextLoader.class)

--- a/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.file.Files;
@@ -41,8 +42,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
                 "white-label.custom.title: Test Zeebe Simple Monitor",
                 "white-label.custom.css.path: css/test-custom.css",
                 "white-label.custom.js.path: js/test-custom.js",
+								"logging.level.io.zeebe.monitor: info",
         })
 @AutoConfigureMockMvc
+@ActiveProfiles("junittest")
 public class ViewControllerTest {
 
   @Autowired

--- a/src/test/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporterTest.java
+++ b/src/test/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporterTest.java
@@ -1,0 +1,56 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.ElementInstanceEntity;
+import io.zeebe.monitor.repository.ElementInstanceRepository;
+import io.zeebe.monitor.repository.ZeebeRepositoryTest;
+import io.zeebe.monitor.zeebe.ZeebeNotificationService;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ContextConfiguration(
+    classes = {ProcessAndElementImporter.class,
+        ZeebeNotificationService.class}
+)
+public class ProcessAndElementImporterTest extends ZeebeRepositoryTest {
+
+  @Autowired
+  ProcessAndElementImporter processAndElementImporter;
+
+  @Autowired
+  ElementInstanceRepository elementInstanceRepository;
+
+  @MockBean
+  SimpMessagingTemplate simpMessagingTemplate;
+
+  @Test
+  public void only_storing_first_variable_event_prevents_duplicate_PartitionID_and_Position() {
+    // given
+    Schema.ProcessInstanceRecord processInstance1 = createElementInstanceWithId("first-elementId");
+    processAndElementImporter.importProcessInstance(processInstance1);
+
+    // when
+    Schema.ProcessInstanceRecord processInstance2 = createElementInstanceWithId("second-elementId");
+    processAndElementImporter.importProcessInstance(processInstance2);
+
+    // then
+    Iterable<ElementInstanceEntity> all = elementInstanceRepository.findAll();
+    assertThat(all).hasSize(1);
+    assertThat(all.iterator().next().getElementId()).isEqualTo("first-elementId");
+  }
+
+  private Schema.ProcessInstanceRecord createElementInstanceWithId(String elementId) {
+    return Schema.ProcessInstanceRecord.newBuilder()
+        .setElementId(elementId)
+        .setMetadata(Schema.RecordMetadata.newBuilder()
+            .setIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED.name()))
+        .build();
+  }
+
+}

--- a/src/test/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporterTest.java
+++ b/src/test/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporterTest.java
@@ -6,7 +6,7 @@ import io.zeebe.monitor.entity.ElementInstanceEntity;
 import io.zeebe.monitor.repository.ElementInstanceRepository;
 import io.zeebe.monitor.repository.ZeebeRepositoryTest;
 import io.zeebe.monitor.zeebe.ZeebeNotificationService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -49,6 +49,8 @@ public class ProcessAndElementImporterTest extends ZeebeRepositoryTest {
     return Schema.ProcessInstanceRecord.newBuilder()
         .setElementId(elementId)
         .setMetadata(Schema.RecordMetadata.newBuilder()
+            .setPosition(333L)
+            .setPartitionId(55555)
             .setIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED.name()))
         .build();
   }

--- a/src/test/java/io/zeebe/monitor/zeebe/importers/VariableImporterTest.java
+++ b/src/test/java/io/zeebe/monitor/zeebe/importers/VariableImporterTest.java
@@ -1,0 +1,48 @@
+package io.zeebe.monitor.zeebe.importers;
+
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.monitor.entity.VariableEntity;
+import io.zeebe.monitor.repository.VariableRepository;
+import io.zeebe.monitor.repository.ZeebeRepositoryTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ContextConfiguration(
+    classes = {VariableImporter.class}
+)
+public class VariableImporterTest extends ZeebeRepositoryTest {
+
+  @Autowired
+  VariableImporter variableImporter;
+
+  @Autowired
+  VariableRepository variableRepository;
+
+  @Test
+  public void only_storing_first_variable_event_prevents_duplicate_PartitionID_and_Position() {
+    // given
+    Schema.VariableRecord record1 = createVariableRecordWithName("first-variable");
+    variableImporter.importVariable(record1);
+
+    // when
+    Schema.VariableRecord record2 = createVariableRecordWithName("second-variable");
+    variableImporter.importVariable(record2);
+
+    // then
+    Iterable<VariableEntity> all = variableRepository.findAll();
+    assertThat(all).hasSize(1);
+    assertThat(all.iterator().next().getName()).isEqualTo("first-variable");
+  }
+
+  private Schema.VariableRecord createVariableRecordWithName(String name) {
+    return Schema.VariableRecord.newBuilder()
+        .setMetadata(Schema.RecordMetadata.newBuilder()
+            .setPartitionId(123)
+            .setPosition(456L))
+        .setName(name)
+        .build();
+  }
+}

--- a/src/test/java/io/zeebe/monitor/zeebe/importers/VariableImporterTest.java
+++ b/src/test/java/io/zeebe/monitor/zeebe/importers/VariableImporterTest.java
@@ -4,7 +4,7 @@ import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.VariableEntity;
 import io.zeebe.monitor.repository.VariableRepository;
 import io.zeebe.monitor.repository.ZeebeRepositoryTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 

--- a/src/test/resources/application-junittest.yaml
+++ b/src/test/resources/application-junittest.yaml
@@ -1,0 +1,4 @@
+logging:
+  level:
+    root: WARN
+    io.zeebe: INFO


### PR DESCRIPTION
Based on the discussion in PR #280,
this is the actual bug fix for issue #278.
This PR depends on #284, because of the author's preference to split #280 into separate PRs.

This bug fix uses the approach of transient creation of an ID, based on PartitionID and Position.
Also, tests are added, to show how it works.
The duplicate check is implemented again.