### PR TITLE
Add error handling in case of process definition not found

### DIFF
--- a/src/main/java/io/zeebe/monitor/rest/ViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ViewController.java
@@ -39,6 +39,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.transaction.Transactional;
 import java.io.ByteArrayInputStream;
@@ -54,11 +55,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 @Controller
 public class ViewController {
 
   private static final int FIRST_PAGE = 0;
   private static final int PAGE_RANGE = 2;
+
+  private static final String WARNING_NO_XML_RESOURCE_FOUND = "WARNING-NO-XML-RESOURCE-FOUND";
 
   private static final List<String> PROCESS_INSTANCE_ENTERED_INTENTS =
       Arrays.asList("ELEMENT_ACTIVATED");
@@ -143,7 +148,7 @@ public class ViewController {
     final ProcessEntity process =
         processRepository
             .findByKey(key)
-            .orElseThrow(() -> new RuntimeException("No process found with key: " + key));
+            .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "No process found with key: " + key));
 
     model.put("process", toDto(process));
     model.put("resource", getProcessResource(process));
@@ -270,8 +275,9 @@ public class ViewController {
     final ProcessInstanceEntity instance =
         processInstanceRepository
             .findByKey(key)
-            .orElseThrow(() -> new RuntimeException("No process instance found with key: " + key));
+            .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "No process instance found with key: " + key));
 
+    model.put("resource", WARNING_NO_XML_RESOURCE_FOUND);
     processRepository
         .findByKey(instance.getProcessDefinitionKey())
         .ifPresent(process -> model.put("resource", getProcessResource(process)));

--- a/src/main/resources/templates/components/bpmn-diagram.html
+++ b/src/main/resources/templates/components/bpmn-diagram.html
@@ -1,4 +1,6 @@
-<div id="diagramCanvas" class="bpmn-io-viewer-height"></div>
+<div id="diagramCanvas" class="bpmn-io-viewer-height">
+    <div id="diagramWarningText" style="display: none" class="alert alert-warning" role="alert"></div>
+</div>
 
 
 <script>
@@ -7,16 +9,25 @@
 	}, false);
 
   function renderDiagram() {
-  	var resource = `{{{resource}}}`;
+    var resource = `{{{resource}}}`;
+    if (resource === 'WARNING-NO-XML-RESOURCE-FOUND') {
+      let warningTextElement = document.getElementById('diagramWarningText');
+      warningTextElement.appendChild(document.createTextNode('There was no process definition nor BPMN diagram found for this instance.'));
+      warningTextElement.style.display = 'block';
+    } else {
+      renderBpmnDiagramFromXml(resource)
+    }
+  }
 
-    var BpmnViewer = window.BpmnJS;
-    viewer = new BpmnViewer({container: '#diagramCanvas', width: '100%', height: '100%'});
+  function renderBpmnDiagramFromXml(xmlString) {
+      var BpmnViewer = window.BpmnJS;
+      viewer = new BpmnViewer({container: '#diagramCanvas', width: '100%', height: '100%'});
 
-    canvas = viewer.get('canvas');
-    eventBus = viewer.get("eventBus");
-    overlays = viewer.get("overlays");
+      canvas = viewer.get('canvas');
+      eventBus = viewer.get("eventBus");
+      overlays = viewer.get("overlays");
 
-      viewer.importXML(resource, function(err) {
+      viewer.importXML(xmlString, function(err) {
 			if (err) {
         showError("Diagram rendering: " + err);
 			} else {


### PR DESCRIPTION
Since Zeebe Simple Monitor was build to support developers on local testing etc.,
I found myself in situations, where e.g. the process definition was no more available in the database.
This caused the BPMN diagram renderer to fail with exception and was confusing for me as user of Simple Monitor.

Unfortunately, I can't trace back, what caused the fact, that the process was not available, but this would be worth another PR, right? ;)
This PR just makes the renderer more robust in case of in-consistent data.

Additionally, I did replace the ```throw new RuntimeException()``` in the ViewController
with proper ```throw new ResponseStatusException()``` which will also improve/relate to PR #286 "Feature/error handler2".

Just for the record, the error can be reproduced, if someone deletes the process definition from an existing database.
When requesting a single instance, e.g. ```curl http://localhost:8082/views/instances/2251799814000236 ```
the response looks like this

```json
{
    "timestamp": "2021-08-09T15:03:04.154+00:00",
    "status": 500,
    "error": "Internal Server Error",
    "trace": "com.samskivert.mustache.MustacheException$Context: No method or field with name 'resource' on line 10
	at com.samskivert.mustache.Template.checkForMissing(Template.java:344)
	at com.samskivert.mustache.Template.getValue(Template.java:247)
	at com.samskivert.mustache.Template.getValueOrDefault(Template.java:292)
	at com.samskivert.mustache.Mustache$VariableSegment.execute(Mustache.java:872)
	at com.samskivert.mustache.Template.executeSegs(Template.java:170)
	at com.samskivert.mustache.Mustache$IncludedTemplateSegment.execute(Mustache.java:831)
	at com.samskivert.mustache.Template.executeSegs(Template.java:170)
	at com.samskivert.mustache.Template.execute(Template.java:137)
	at org.springframework.boot.web.servlet.view.MustacheView.renderMergedTemplateModel(MustacheView.java:80)
	at org.springframework.web.servlet.view.AbstractTemplateView.renderMergedOutputModel(AbstractTemplateView.java:179)
	at org.springframework.web.servlet.view.AbstractView.render(AbstractView.java:316)
	at org.springframework.web.servlet.DispatcherServlet.render(DispatcherServlet.java:1393)
	at org.springframework.web.servlet.DispatcherServlet.processDispatchResult(DispatcherServlet.java:1138)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1077)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:962)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:626)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:733)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:542)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:143)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78)
	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:764)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:357)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:374)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:893)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1707)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Unknown Source)
",
    "message": "No method or field with name 'resource' on line 10",
    "path": "/views/instances/2251799814000236"
}
```