### PR TITLE
adding indices to tables improves responsiveness 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,32 @@
 Upgrade documentation for Zeebe Simple Monitor 
 ==================================================
 
+## Upgrading from v2.1.0
+
+In order to improve database lookup performance, a handful of indices was added to the database structure.
+Zeebe Simple Monitor will not alter existing database tables automatically, but if you have a PostgreSQL
+or other DB running, you may want to alter the table structures manually, in order to improve lookup performance.
+Again, this is an optional step - Zeebe Simple Monitor will work as is without it - just a bit slower response times.
+
+Of course, if you use an in-memory DB or do not need to keep prior data, then simply drop all tables and sequences,
+and let Zeebe Simple Monitor create them again for you (automatic creation works).
+
+### Upgrade procedure
+
+1. stop Zeebe Simple Monitor (v2.1.0)
+2. run the SQL script below against your PostgreSQL Database
+3. start up Zeebe Simple Monitor (new version)
+
+```sql
+CREATE INDEX error_processInstanceKeyIndex ON error (process_instance_key_);
+CREATE INDEX incident_processInstanceKeyIndex ON incident (process_instance_key_);
+CREATE INDEX job_processInstanceKeyIndex ON job (process_instance_key_);
+CREATE INDEX message_subscription_processInstanceKeyIndex ON message_subscription (process_instance_key_);
+CREATE INDEX timer_processInstanceKeyIndex ON timer (process_instance_key_);
+```
+(This SQL was developed and tested using a recent PostgreSQL instance.
+You might need to adopt that if you're using another Database)
+
 ## Upgrading from v2.0.0
 
 Due to some issues with storing variables and element instances, the database structure changed.

--- a/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
@@ -19,7 +19,8 @@ import javax.persistence.*;
 
 @Entity(name = "ELEMENT_INSTANCE")
 @Table(indexes = {
-    // performance reason, because we use it in the ElementInstanceRepository.findByProcessInstanceKey()
+    // performance reason, because we use it in the
+    // {@link io.zeebe.monitor.repository.ElementInstanceRepository#findByProcessInstanceKey(long)}
     @Index(name = "element_instance_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
 })
 public class ElementInstanceEntity {

--- a/src/main/java/io/zeebe/monitor/entity/ErrorEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/ErrorEntity.java
@@ -15,12 +15,14 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
+import javax.persistence.*;
 
 @Entity(name = "ERROR")
+@Table(indexes = {
+    // performance reason, because we use it in the
+    // {@link io.zeebe.monitor.repository.ErrorRepository#findByProcessInstanceKey(long)}
+    @Index(name = "error_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class ErrorEntity {
 
   @Id

--- a/src/main/java/io/zeebe/monitor/entity/IncidentEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/IncidentEntity.java
@@ -15,12 +15,14 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
+import javax.persistence.*;
 
 @Entity(name = "INCIDENT")
+@Table(indexes = {
+    // performance reason, because we use it in the
+    // {@link io.zeebe.monitor.repository.IncidentRepository#findByProcessInstanceKey(long)}
+    @Index(name = "incident_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class IncidentEntity {
 
   @Id

--- a/src/main/java/io/zeebe/monitor/entity/JobEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/JobEntity.java
@@ -15,11 +15,14 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity(name = "JOB")
+@Table(indexes = {
+    // performance reason, because we use it in the
+    // {@link io.zeebe.monitor.repository.JobRepository#findByProcessInstanceKey(long)}
+    @Index(name = "job_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class JobEntity {
 
   @Id

--- a/src/main/java/io/zeebe/monitor/entity/MessageSubscriptionEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/MessageSubscriptionEntity.java
@@ -15,11 +15,14 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity(name = "MESSAGE_SUBSCRIPTION")
+@Table(indexes = {
+    // performance reason, because we use it in the
+    // {@link io.zeebe.monitor.repository.MessageSubscriptionRepository#findByProcessInstanceKey(long)}
+    @Index(name = "message_subscription_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class MessageSubscriptionEntity {
 
   @Id

--- a/src/main/java/io/zeebe/monitor/entity/TimerEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/TimerEntity.java
@@ -15,11 +15,14 @@
  */
 package io.zeebe.monitor.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity(name = "TIMER")
+@Table(indexes = {
+    // performance reason, because we use it in the
+    // {@link io.zeebe.monitor.repository.TimerRepository#findByProcessInstanceKey(long)}
+    @Index(name = "timer_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+})
 public class TimerEntity {
 
   @Id


### PR DESCRIPTION
This PR add missing indices to columns, which are used frequently.

I have a Zeebe Simple Monitor running and observed decreasing responsiveness/response times of the UI,
because I did some performance testing. In my scenario, I had 3 million process instances created.
This led to timeouts in the DB lookup. 
Adding indices not only solved the problem but also made the UI significantly more responsive.

Any feedback is welcome.