### PR TITLE
feat(UI): forward Zeebe client exceptions to the web UI

### DIFF
--- a/src/main/java/io/zeebe/monitor/rest/ExceptionHandler.java
+++ b/src/main/java/io/zeebe/monitor/rest/ExceptionHandler.java
@@ -1,37 +1,52 @@
 package io.zeebe.monitor.rest;
 
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.zeebe.monitor.rest.ui.ErrorMessage;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 
 @ControllerAdvice
 public class ExceptionHandler {
 
-	private static final Logger LOG = LoggerFactory.getLogger(ExceptionHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExceptionHandler.class);
 
-	private final WhitelabelProperties whitelabelProperties;
+  private final WhitelabelProperties whitelabelProperties;
 
-	public ExceptionHandler(WhitelabelProperties whitelabelProperties) {
-		this.whitelabelProperties = whitelabelProperties;
-	}
+  public ExceptionHandler(WhitelabelProperties whitelabelProperties) {
+    this.whitelabelProperties = whitelabelProperties;
+  }
 
-	@org.springframework.web.bind.annotation.ExceptionHandler(RuntimeException.class)
-	public String handleRuntimeException(RuntimeException exc, final Model model) {
-		LOG.error(exc.getMessage(), exc);
+  @org.springframework.web.bind.annotation.ExceptionHandler(value = {ClientException.class})
+  protected ResponseEntity<Object> handleZeebeClientException(final RuntimeException ex, final WebRequest request) {
+    LOG.debug("Zeebe Client Exception caught and forwarding to UI.", ex);
+    return ResponseEntity
+        .status(HttpStatus.FAILED_DEPENDENCY)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(new ErrorMessage(ex.getMessage()));
+  }
 
-		model.addAttribute("error", exc.getClass().getSimpleName());
-		model.addAttribute("message", exc.getMessage());
-		model.addAttribute("trace", ExceptionUtils.getStackTrace(exc));
+  @org.springframework.web.bind.annotation.ExceptionHandler(RuntimeException.class)
+  public String handleRuntimeException(final RuntimeException exc, final Model model) {
+    LOG.error(exc.getMessage(), exc);
 
-		model.addAttribute("custom-title", whitelabelProperties.getCustomTitle());
-		model.addAttribute("context-path", whitelabelProperties.getBasePath());
-		model.addAttribute("logo-path", whitelabelProperties.getLogoPath());
-		model.addAttribute("custom-css-path", whitelabelProperties.getCustomCssPath());
-		model.addAttribute("custom-js-path", whitelabelProperties.getCustomCssPath());
+    model.addAttribute("error", exc.getClass().getSimpleName());
+    model.addAttribute("message", exc.getMessage());
+    model.addAttribute("trace", ExceptionUtils.getStackTrace(exc));
 
-		return "error";
-	}
+    model.addAttribute("custom-title", whitelabelProperties.getCustomTitle());
+    model.addAttribute("context-path", whitelabelProperties.getBasePath());
+    model.addAttribute("logo-path", whitelabelProperties.getLogoPath());
+    model.addAttribute("custom-css-path", whitelabelProperties.getCustomCssPath());
+    model.addAttribute("custom-js-path", whitelabelProperties.getCustomCssPath());
+
+    return "error";
+  }
 
 }

--- a/src/main/java/io/zeebe/monitor/rest/ui/ErrorMessage.java
+++ b/src/main/java/io/zeebe/monitor/rest/ui/ErrorMessage.java
@@ -1,0 +1,18 @@
+package io.zeebe.monitor.rest.ui;
+
+public class ErrorMessage {
+
+  private String message;
+
+  public ErrorMessage(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/io/zeebe/monitor/rest/ui/ProcessInstanceNotification.java
+++ b/src/main/java/io/zeebe/monitor/rest/ui/ProcessInstanceNotification.java
@@ -1,4 +1,4 @@
-package io.zeebe.monitor.rest;
+package io.zeebe.monitor.rest.ui;
 
 public class ProcessInstanceNotification {
 

--- a/src/main/java/io/zeebe/monitor/rest/ui/ZeebeClusterNotification.java
+++ b/src/main/java/io/zeebe/monitor/rest/ui/ZeebeClusterNotification.java
@@ -1,0 +1,29 @@
+package io.zeebe.monitor.rest.ui;
+
+public class ZeebeClusterNotification {
+
+  private Type type;
+  private String message;
+
+  public enum Type {
+    INFORMATION,
+    SUCCESS,
+    ERROR
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public void setType(final Type type) {
+    this.type = type;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/ZeebeNotificationService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/ZeebeNotificationService.java
@@ -1,7 +1,8 @@
 package io.zeebe.monitor.zeebe;
 
-import io.zeebe.monitor.rest.ProcessInstanceNotification;
-import io.zeebe.monitor.rest.ProcessInstanceNotification.Type;
+import io.zeebe.monitor.rest.ui.ProcessInstanceNotification;
+import io.zeebe.monitor.rest.ui.ProcessInstanceNotification.Type;
+import io.zeebe.monitor.rest.ui.ZeebeClusterNotification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -48,8 +49,20 @@ public class ZeebeNotificationService {
     sendNotification(notification);
   }
 
+  public void sendZeebeClusterError(final String message) {
+    final ZeebeClusterNotification notification = new ZeebeClusterNotification();
+    notification.setMessage(message);
+    notification.setType(ZeebeClusterNotification.Type.ERROR);
+    sendNotification(notification);
+  }
+
   private void sendNotification(final ProcessInstanceNotification notification) {
     final var destination = basePath + "notifications/process-instance";
+    webSocket.convertAndSend(destination, notification);
+  }
+
+  private void sendNotification(final ZeebeClusterNotification notification) {
+    final var destination = basePath + "notifications/zeebe-cluster";
     webSocket.convertAndSend(destination, notification);
   }
 }

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -1,21 +1,73 @@
+/**
+ * @typedef ErrorMessage
+ * @type {object}
+ * @property {string} message
+ */
+
+/**
+ * @typedef ProcessInstanceNotification
+ * @type {object}
+ * @property {number} processInstanceKey
+ * @property {number} processDefinitionKey
+ * @property {string} type
+ */
+
+/**
+ * @typedef ZeebeClusterNotification
+ * @type {object}
+ * @property {string} message
+ * @property {string} type
+ */
+
+/**
+ * @param {string} elementId - the HTML element ID to attach the text to
+ * @param {string} title - the title for the message
+ * @param {string} message - the actual text message
+ */
+function appendAndSowMessageToElement(elementId, title, message) {
+    var dataTexts = jQuery("#" + elementId + " [data-text]");
+    var length = dataTexts.length;
+    for (var i = 0; i < Math.max(0, length - 3); i++) {
+        jQuery(dataTexts[i]).fadeOut(dataTexts[i].remove);
+    }
+    var newTextElement = jQuery(jQuery("<div/>"));
+    newTextElement.hide();
+    newTextElement.attr("data-text", "");
+    newTextElement.append(jQuery("<strong>" + title + "</strong>"));
+    var textSpanElement = jQuery("<span/>");
+    textSpanElement.text(message);
+    newTextElement.append(textSpanElement);
+    jQuery("#" + elementId + " button").before(newTextElement);
+    jQuery("#" + elementId).show();
+    newTextElement.fadeIn();
+}
+
+/**
+ * @param {string} message - the actual text message
+ */
 function showError(message) {
-    document.getElementById("errorText").innerHTML = message;
-    $('#errorPanel').show();
+    appendAndSowMessageToElement("errorPanel", "Error: ", message);
 }
 
+/**
+ * @param {string} message - the actual text message
+ */
 function showSuccess(message) {
-    document.getElementById("successText").innerHTML = message;
-    $('#successPanel').show();
+    appendAndSowMessageToElement("successPanel", "Success: ", message);
 }
 
+/**
+ * @param {string} message - the actual text message
+ */
 function showInfo(message) {
-    document.getElementById("infoText").innerHTML = message;
-    $('#infoPanel').show();
+    appendAndSowMessageToElement("infoPanel", "Info: ", message);
 }
 
 function showErrorResonse(xhr, ajaxOptions, thrownError) {
     if (xhr.responseJSON) {
-        showError(xhr.responseJSON.message);
+        /** @type {ErrorMessage} */
+        let errorMessage = xhr.responseJSON;
+        showError(errorMessage.message);
     } else {
         showError(thrownError);
     }
@@ -43,7 +95,10 @@ function connect() {
     stompClient = Stomp.over(socket);
     stompClient.connect({}, function (frame) {
         stompClient.subscribe(buildPath('notifications/process-instance'), function (message) {
-            handleMessage(JSON.parse(message.body));
+            handleProcessInstanceNotification(JSON.parse(message.body));
+        });
+        stompClient.subscribe(buildPath('notifications/zeebe-cluster'), function (message) {
+            handleZeebeClusterNotification(JSON.parse(message.body));
         });
     });
 }
@@ -59,7 +114,10 @@ function sendMessage(msg) {
         JSON.stringify(msg));
 }
 
-function handleMessage(notification) {
+/**
+ * @param notification {ProcessInstanceNotification}
+ */
+function handleProcessInstanceNotification(notification) {
 
     if (subscribedProcessInstanceKeys.includes(notification.processInstanceKey)) {
         showInfo('Process instance has changed.');
@@ -68,6 +126,13 @@ function handleMessage(notification) {
     if (subscribedProcessDefinitionKeys.includes(notification.processDefinitionKey)) {
         showInfo('Instance(s) of this process have changed.');
     }
+}
+
+/**
+ * @param notification {ZeebeClusterNotification}
+ */
+function handleZeebeClusterNotification(notification) {
+    showError(notification.message)
 }
 
 function subscribeForProcessInstance(key) {

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -27,18 +27,30 @@
 function appendAndSowMessageToElement(elementId, title, message) {
     var dataTexts = jQuery("#" + elementId + " [data-text]");
     var length = dataTexts.length;
+    // skip duplicates
+    if (length > 0) {
+        if (jQuery(dataTexts[length - 1]).text().endsWith(message)) {
+            return;
+        }
+    }
+    // drop the top of the stack == the oldest entries
     for (var i = 0; i < Math.max(0, length - 3); i++) {
         jQuery(dataTexts[i]).fadeOut(dataTexts[i].remove);
     }
-    var newTextElement = jQuery(jQuery("<div/>"));
+    var newTextElement = jQuery("<div/>");
     newTextElement.hide();
     newTextElement.attr("data-text", "");
     newTextElement.append(jQuery("<strong>" + title + "</strong>"));
     var textSpanElement = jQuery("<span/>");
     textSpanElement.text(message);
     newTextElement.append(textSpanElement);
-    jQuery("#" + elementId + " button").before(newTextElement);
-    jQuery("#" + elementId).show();
+    var panelElement = jQuery("#" + elementId);
+    if (length === 0) {
+        panelElement.prepend(newTextElement);
+    } else {
+        jQuery(dataTexts[dataTexts.length - 1]).after(newTextElement);
+    }
+    panelElement.show();
     newTextElement.fadeIn();
 }
 

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -54,24 +54,24 @@
 <div class="container-fluid">
 
     <div id="errorPanel" class="alert alert-danger alert-dismissible fade show" style="display:none;" role="alert">
-        <strong>Error:</strong> <span id="errorText"></span>
-        <button type="button" class="close" aria-label="Close" onclick="$('.alert').hide()">
+        <!-- text will be inserted via jQuery at runtime -->
+        <button type="button" class="close" aria-label="Close" onclick="(function(){jQuery('#errorPanel [data-text]').remove(); jQuery('#errorPanel').hide()}())">
             <span aria-hidden="true">&times;</span>
         </button>
     </div>
 
     <div id="successPanel" class="alert alert-success alert-dismissible fade show" style="display:none;" role="alert">
-        <strong>Success:</strong> <span id="successText"></span>
+        <!-- text will be inserted via jQuery at runtime -->
         (<a href="#" onClick="reload()">Refresh</a>)
-        <button type="button" class="close" aria-label="Close" onclick="$('.alert').hide()">
+        <button type="button" class="close" aria-label="Close" onclick="(function(){jQuery('#successPanel [data-text]').remove(); jQuery('#successPanel').hide()}())">
             <span aria-hidden="true">&times;</span>
         </button>
     </div>
 
     <div id="infoPanel" class="alert alert-primary alert-dismissible fade show" style="display:none;" role="alert">
-        <strong>Info:</strong> <span id="infoText"></span>
+        <!-- text will be inserted via jQuery at runtime -->
         (<a href="#" onClick="reload()">Refresh</a>)
-        <button type="button" class="close" aria-label="Close" onclick="$('.alert').hide()">
+        <button type="button" class="close" aria-label="Close" onclick="(function(){jQuery('#infoPanel [data-text]').remove(); jQuery('#infoPanel').hide()}())">
             <span aria-hidden="true">&times;</span>
         </button>
     </div>

--- a/src/test/java/io/zeebe/monitor/rest/AbstractViewOrResourceTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/AbstractViewOrResourceTest.java
@@ -1,0 +1,61 @@
+package io.zeebe.monitor.rest;
+
+import io.zeebe.monitor.repository.*;
+import io.zeebe.monitor.zeebe.ZeebeHazelcastService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "white-label.logo.path: img/test-logo.png",
+        "white-label.custom.title: Test Zeebe Simple Monitor",
+        "white-label.custom.css.path: css/test-custom.css",
+        "white-label.custom.js.path: js/test-custom.js",
+        "logging.level.io.zeebe.monitor: info",
+    })
+@AutoConfigureMockMvc
+@ActiveProfiles("junittest")
+public abstract class AbstractViewOrResourceTest {
+
+  @LocalServerPort
+  protected int port;
+  @Autowired
+  protected MockMvc mockMvc;
+  @Autowired
+  protected TestRestTemplate restTemplate;
+  @Autowired
+  protected ViewController controller;
+
+
+  @MockBean
+  protected HazelcastConfigRepository hazelcastConfigRepository;
+  @MockBean
+  protected ZeebeHazelcastService zeebeHazelcastService;
+  @MockBean
+  protected ProcessRepository processRepository;
+  @MockBean
+  protected ProcessInstanceRepository processInstanceRepository;
+  @MockBean
+  protected ElementInstanceRepository activityInstanceRepository;
+  @MockBean
+  protected IncidentRepository incidentRepository;
+  @MockBean
+  protected JobRepository jobRepository;
+  @MockBean
+  protected MessageRepository messageRepository;
+  @MockBean
+  protected MessageSubscriptionRepository messageSubscriptionRepository;
+  @MockBean
+  protected TimerRepository timerRepository;
+  @MockBean
+  protected VariableRepository variableRepository;
+  @MockBean
+  protected ErrorRepository errorRepository;
+
+}

--- a/src/test/java/io/zeebe/monitor/rest/ProcessInstanceResourceTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ProcessInstanceResourceTest.java
@@ -1,11 +1,11 @@
 package io.zeebe.monitor.rest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.zeebe.monitor.zeebe.ZeebeNotificationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/test/java/io/zeebe/monitor/rest/ProcessInstanceResourceTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ProcessInstanceResourceTest.java
@@ -1,0 +1,53 @@
+package io.zeebe.monitor.rest;
+
+import io.zeebe.monitor.zeebe.ZeebeNotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpStatus.FAILED_DEPENDENCY;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ProcessInstanceResourceTest extends AbstractViewOrResourceTest {
+
+  @Autowired
+  protected ProcessInstanceResource processInstanceResource;
+
+  @MockBean()
+  private ZeebeNotificationService zeebeNotificationServiceMock;
+
+  @Test
+  void resolve_incident_command_is_send_even_when_prior_change_job_retries_command_fails() throws Exception {
+    // given
+    final ResolveIncidentDto dto = new ResolveIncidentDto();
+    dto.setIncidentKey(123456789);
+    dto.setJobKey(999L);
+    dto.setRemainingRetries(1);
+
+    // when & then
+    this.mockMvc.perform(
+        put("/api/instances/{key}/resolve-incident", 123456789)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createDummyRequestBody(dto))
+    ).andExpect(status().is(FAILED_DEPENDENCY.value()));
+
+    // then
+    verify(zeebeNotificationServiceMock).sendZeebeClusterError(anyString());
+  }
+
+  private byte[] createDummyRequestBody(Object object) throws IOException {
+    try (final ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+      new ObjectMapper().writeValue(buffer, object);
+      return buffer.toByteArray();
+    }
+  }
+
+}

--- a/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ViewControllerTest.java
@@ -2,28 +2,10 @@ package io.zeebe.monitor.rest;
 
 import io.zeebe.monitor.entity.ProcessEntity;
 import io.zeebe.monitor.entity.ProcessInstanceEntity;
-import io.zeebe.monitor.repository.ElementInstanceRepository;
-import io.zeebe.monitor.repository.ErrorRepository;
-import io.zeebe.monitor.repository.HazelcastConfigRepository;
-import io.zeebe.monitor.repository.IncidentRepository;
-import io.zeebe.monitor.repository.JobRepository;
-import io.zeebe.monitor.repository.MessageRepository;
-import io.zeebe.monitor.repository.MessageSubscriptionRepository;
-import io.zeebe.monitor.repository.ProcessInstanceRepository;
-import io.zeebe.monitor.repository.ProcessRepository;
-import io.zeebe.monitor.repository.TimerRepository;
-import io.zeebe.monitor.repository.VariableRepository;
-import io.zeebe.monitor.zeebe.ZeebeHazelcastService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -36,48 +18,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {
-                "white-label.logo.path: img/test-logo.png",
-                "white-label.custom.title: Test Zeebe Simple Monitor",
-                "white-label.custom.css.path: css/test-custom.css",
-                "white-label.custom.js.path: js/test-custom.js",
-								"logging.level.io.zeebe.monitor: info",
-        })
-@AutoConfigureMockMvc
-@ActiveProfiles("junittest")
-public class ViewControllerTest {
-
-  @Autowired
-  private ViewController controller;
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @MockBean
-  private HazelcastConfigRepository hazelcastConfigRepository;
-  @MockBean
-  private ZeebeHazelcastService zeebeHazelcastService;
-  @MockBean
-  private ProcessRepository processRepository;
-  @MockBean
-  private ProcessInstanceRepository processInstanceRepository;
-  @MockBean
-  private ElementInstanceRepository activityInstanceRepository;
-  @MockBean
-  private IncidentRepository incidentRepository;
-  @MockBean
-  private JobRepository jobRepository;
-  @MockBean
-  private MessageRepository messageRepository;
-  @MockBean
-  private MessageSubscriptionRepository messageSubscriptionRepository;
-  @MockBean
-  private TimerRepository timerRepository;
-  @MockBean
-  private VariableRepository variableRepository;
-  @MockBean
-  private ErrorRepository errorRepository;
+public class ViewControllerTest extends AbstractViewOrResourceTest {
 
   @BeforeEach
   public void setUp() throws Exception {


### PR DESCRIPTION
### Motivation

Using Simple Monitor during development is somehow awkward because e.g. BPMN errors during deployment,
or actions like "resolve incident" do not show underlying Zeebe errors.
This PR attempts to improve this by a) enabling multiple errors shown at once and b) actively pushing ZeebeClientException messages to the UI.

### Change Summary

* add: forwarding/pushing ZeebeClient errors to the web UI
* add: allow multiple errors, info, and success messages displayed at once in the UI
* add: Test for ProcessInstanceResource
* add: extended ExceptionHandler to push ZeebeClientExceptions to the UI 
* change: introduce abstract test class for ViewController and Resource tests
* change: when during incident resolving the job can't be changed, there's still an attempt to resolve the incident
* fix: closing error panel also closes info panel (now each panel must be closed individually)

example screenshot, how multiple errors are visualized...
![Screenshot 2022-01-12 at 15 08 40](https://user-images.githubusercontent.com/1189394/149155946-77f9c596-0f32-479f-b827-e03c0f2d2d07.png)

PS: there's one related change, I hope this is OK to be in here as well...
when clicking "resolve incident" in the backend two commands are sent to Zeebe. that's not obvious and slightly differs from e.g. using the CLI. So I adopted the implementation, that the second command is always fired, no matter if "update retries" fails, the resolve command is fired too. (I hope this helps hunt down the issue when Zeebe's housekeeping kicks in and Simple Monitor's data is no more in synch.)