### PR TITLE
fix(zeebe-client): use gatewayAddress instead of deprecated contactPoint

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ zeebe:
 
 
   client:
-    broker.contactPoint: 127.0.0.1:26500
+    broker.gatewayAddress: 127.0.0.1:26500
     security.plaintext: true
 
     worker:


### PR DESCRIPTION
There was a change in Zeebe configuration, that ```contactPoint``` was deprecated by https://github.com/camunda-cloud/zeebe/pull/5345

this PR just uses ```gatewayAddress``` instead.