### PR TITLE
feat(ui): show ⍰ as default value in case of missing variables in mustache templates

### DIFF
--- a/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
+++ b/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
@@ -15,6 +15,7 @@
  */
 package io.zeebe.monitor;
 
+import com.samskivert.mustache.Mustache;
 import io.camunda.zeebe.spring.client.EnableZeebeClient;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -52,5 +53,11 @@ public class ZeebeSimpleMonitorApp {
     executor.setQueueCapacity(32);
     executor.initialize();
     return executor;
+  }
+
+  @Bean
+  public Mustache.Compiler configureFallbackValueForMissingVariablesInMustacheTemplates(
+      Mustache.TemplateLoader templateLoader) {
+    return Mustache.compiler().defaultValue("⍰").withLoader(templateLoader);
   }
 }


### PR DESCRIPTION
## Motivation

while developing and testing with Zeebe, the PostgreSQL DB sometimes is out of synch and makes Simple Monitor fall flat,
during rendering the mustache template. This includes the custom /error page, which is still a white page, even with all exception handlers in place.

This PR simply places a ⍰ character as default, so rendering passes through and just the special character is placed,
where the missing variable was used. This can look like this:
<img width="1680" alt="Screenshot 2022-01-26 at 15 10 32" src="https://user-images.githubusercontent.com/1189394/151184221-77a75925-3cc7-4803-8fbb-6e1581b9b579.png">
 
I know this default value violates a bit the "fail fast" principle.
But I found it more annoying to analyze broken HTML/screenshots and search for exceptions in the log.
E.g. recently a field 'elementId' was not populated ... and its used multiple times - so the hunt for the broken template did start :/
This approach seems to be more indicative that some data might be corrupt - since this is a typical replacement character. .
So in summary I consider this default/replacement value a better solution over fail fast.

Any feedback is welcome.