### PR TITLE
feature(ui): download button for the BPMN definition

### DIFF
--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -668,3 +668,52 @@ function listSort(sortProperty, sortElement) {
 }
 
 // --------------------------------------------------------------------
+
+function openSaveFileDialog (data, filename, mimetype) {
+    'use strict';
+
+    if (!data) return;
+
+    var blob = data.constructor !== Blob
+        ? new Blob([data], {type: mimetype || 'application/octet-stream'})
+        : data ;
+
+    if (navigator.msSaveBlob) {
+        navigator.msSaveBlob(blob, filename);
+        return;
+    }
+
+    var lnk = document.createElement('a'),
+        url = window.URL,
+        objectURL;
+
+    if (mimetype) {
+        lnk.type = mimetype;
+    }
+
+    lnk.download = filename || 'untitled';
+    lnk.href = objectURL = url.createObjectURL(blob);
+    lnk.dispatchEvent(new MouseEvent('click'));
+    setTimeout(url.revokeObjectURL.bind(url, objectURL));
+
+}
+
+function onBpmnDownloadClicked(){
+    'use strict';
+    var filename = $('#bpmnDownloadLink').attr('download');
+    openSaveFileDialog(RAW_BPMN_RESOURCE, filename, 'application/bpmn+xml');
+}
+
+(function checkIfBpmnExistsOrDisableDownloadButton() {
+    'use strict';
+    if (RAW_BPMN_RESOURCE === 'WARNING-NO-XML-RESOURCE-FOUND') {
+        var link = $('#bpmnDownloadLink');
+        link.attr('title', 'BPMN definition not found or broken :-( ');
+        link.removeAttr('href');
+        link.removeAttr('onclick');
+        link.css('color', 'grey');
+        link.css('cursor', 'not-allowed');
+    }
+})();
+
+// --------------------------------------------------------------------

--- a/src/main/resources/templates/components/bpmn-diagram.html
+++ b/src/main/resources/templates/components/bpmn-diagram.html
@@ -8,16 +8,17 @@
 	    renderDiagram();
 	}, false);
 
-  function renderDiagram() {
-    var resource = `{{{resource}}}`;
-    if (resource === 'WARNING-NO-XML-RESOURCE-FOUND') {
-      let warningTextElement = document.getElementById('diagramWarningText');
-      warningTextElement.appendChild(document.createTextNode('There was no process definition nor BPMN diagram found for this instance.'));
-      warningTextElement.style.display = 'block';
-    } else {
-      renderBpmnDiagramFromXml(resource)
+    var RAW_BPMN_RESOURCE = `{{{resource}}}`;
+
+    function renderDiagram() {
+        if (RAW_BPMN_RESOURCE === 'WARNING-NO-XML-RESOURCE-FOUND') {
+            let warningTextElement = document.getElementById('diagramWarningText');
+            warningTextElement.appendChild(document.createTextNode('There was no process definition nor BPMN diagram found for this instance.'));
+            warningTextElement.style.display = 'block';
+        } else {
+            renderBpmnDiagramFromXml(RAW_BPMN_RESOURCE)
+        }
     }
-  }
 
   function renderBpmnDiagramFromXml(xmlString) {
       var BpmnViewer = window.BpmnJS;

--- a/src/main/resources/templates/process-detail-view.html
+++ b/src/main/resources/templates/process-detail-view.html
@@ -37,6 +37,10 @@
                 <th># ended</th>
                 <td>{{countEnded}}</td>
             </tr>
+            <tr>
+                <th>BPMN file</th>
+                <td><a id="bpmnDownloadLink" onclick="onBpmnDownloadClicked();" style="cursor: pointer" download="{{bpmnProcessId}}-v{{version}}.bpmn">&#x2913; download</a></td>
+            </tr>
             {{/process}}
         </table>
 


### PR DESCRIPTION
This is a simple but helpful feature, it allows the download of the (shown) BPMN definition.

Tested in Firefox, Safari, and Chrome (all latest/recent versions).

Any feedback is welcome.

<img width="791" alt="Screenshot 2022-02-15 at 21 40 39" src="https://user-images.githubusercontent.com/1189394/154146500-f0a3080f-8581-4917-86f9-1c7fd8ed84ad.png">

