### PR TITLE
chore(deps): switch to Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Java setup
       uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Cache
       uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Java environment
         uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
         with:
-          java-version: 11
+          java-version: 17
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
       - name: Login to Docker

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <version.hazelcast>5.0.2</version.hazelcast>
 
         <!-- release parent settings -->
-        <version.java>11</version.java>
+        <version.java>17</version.java>
         <java.version>${version.java}</java.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Just a proposal ... since I'm not aware of what "we" are waiting for ;)

- ✅ Tests are green.
- ✅ Application runs (in Docker Compose and from IDE)
- ✅ Annoying Hazelcast warning about reflection to "sun.nio.ch.SelectorImpl" is gone.
- ✅ Docker image with Java 17.0.2 is used (tested with mvn/jib)
- ✅ Github workflow is adopted