### PR TITLE
WiP: feat(config): add 'clusterName' as config option for Hazelcast client

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ zeebe:
       hazelcast:
         connection: localhost:5701
         connectionTimeout: PT30S
+        clusterName: zeebe
 
 spring:
 

--- a/src/main/java/io/zeebe/monitor/zeebe/ZeebeHazelcastService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/ZeebeHazelcastService.java
@@ -21,6 +21,9 @@ public class ZeebeHazelcastService {
   @Value("${zeebe.client.worker.hazelcast.connection}")
   private String hazelcastConnection;
 
+  @Value("${zeebe.client.worker.hazelcast.clusterName}")
+  private String hazelcastClusterName;
+
   @Value("${zeebe.client.worker.hazelcast.connectionTimeout}")
   private String hazelcastConnectionTimeout;
 
@@ -32,7 +35,7 @@ public class ZeebeHazelcastService {
   public void start() {
     final ClientConfig clientConfig = new ClientConfig();
     clientConfig.getNetworkConfig().addAddress(hazelcastConnection);
-
+    clientConfig.setClusterName(hazelcastClusterName);
     final var connectionRetryConfig =
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig();
     connectionRetryConfig.setClusterConnectTimeoutMillis(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ zeebe:
       hazelcast:
         connection: localhost:5701
         connectionTimeout: PT30S
+        clusterName: zeebe
 
 spring:
 


### PR DESCRIPTION
This is quite a small improvement but in order to have multiple clusters using a single Hazelcast (node/instance),
this cluster name config is useful.

Any feedback is welcome.