### PR TITLE
Add basic prometheus instrumentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,16 @@
         </dependency>
 
         <dependency>
+           <groupId>org.springframework.boot</groupId>
+           <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+           <groupId>io.micrometer</groupId>
+           <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.zeebe.hazelcast</groupId>
             <artifactId>zeebe-hazelcast-connector</artifactId>
         </dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,4 @@
 zeebe:
-
-
   client:
     broker.gatewayAddress: 127.0.0.1:26500
     security.plaintext: true
@@ -11,7 +9,6 @@ zeebe:
         connectionTimeout: PT30S
 
 spring:
-
   datasource:
     url: jdbc:h2:mem:zeebe-monitor;DB_CLOSE_DELAY=-1
     username: sa
@@ -44,6 +41,15 @@ logging:
     io.zeebe: INFO
     io.zeebe.monitor: DEBUG
     com.hazelcast: WARN
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics, prometheus
+  metrics:
+    tags:
+      application: zeebe-simple-monitor
 
 white-label:
   logo.path: img/logo.png


### PR DESCRIPTION
This commit adds basic prometheus instrumentation by making use of micrometer.

Exposed metrics are available at: `http://host:port/actuator/prometheus`

<details>
  <summary>Prometheus metrics</summary>

```
# HELP jvm_memory_committed_bytes The amount of memory in bytes that is committed for the Java virtual machine to use
# TYPE jvm_memory_committed_bytes gauge
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Old Gen",} 1.09051904E8
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Eden Space",} 8.8080384E7
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="nonheap",id="Metaspace",} 9.1684864E7
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Survivor Space",} 1.2582912E7
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'profiled nmethods'",} 1.4286848E7
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="nonheap",id="Compressed Class Space",} 1.2582912E7
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'non-nmethods'",} 2555904.0
jvm_memory_committed_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'non-profiled nmethods'",} 3670016.0
# HELP jvm_threads_peak_threads The peak live thread count since the Java virtual machine started or peak was reset
# TYPE jvm_threads_peak_threads gauge
jvm_threads_peak_threads{application="zeebe-simple-monitor",} 57.0
# HELP jvm_buffer_count_buffers An estimate of the number of buffers in the pool
# TYPE jvm_buffer_count_buffers gauge
jvm_buffer_count_buffers{application="zeebe-simple-monitor",id="mapped",} 0.0
jvm_buffer_count_buffers{application="zeebe-simple-monitor",id="mapped - 'non-volatile memory'",} 0.0
jvm_buffer_count_buffers{application="zeebe-simple-monitor",id="direct",} 20.0
# HELP executor_completed_tasks_total The approximate total number of tasks that have completed execution
# TYPE executor_completed_tasks_total counter
executor_completed_tasks_total{application="zeebe-simple-monitor",name="clientInboundChannelExecutor",} 0.0
executor_completed_tasks_total{application="zeebe-simple-monitor",name="messageBrokerTaskScheduler",} 0.0
executor_completed_tasks_total{application="zeebe-simple-monitor",name="asyncExecutor",} 0.0
executor_completed_tasks_total{application="zeebe-simple-monitor",name="brokerChannelExecutor",} 0.0
executor_completed_tasks_total{application="zeebe-simple-monitor",name="clientOutboundChannelExecutor",} 0.0
# HELP process_uptime_seconds The uptime of the Java virtual machine
# TYPE process_uptime_seconds gauge
process_uptime_seconds{application="zeebe-simple-monitor",} 37.094
# HELP executor_active_threads The approximate number of threads that are actively executing tasks
# TYPE executor_active_threads gauge
executor_active_threads{application="zeebe-simple-monitor",name="clientInboundChannelExecutor",} 0.0
executor_active_threads{application="zeebe-simple-monitor",name="messageBrokerTaskScheduler",} 0.0
executor_active_threads{application="zeebe-simple-monitor",name="asyncExecutor",} 0.0
executor_active_threads{application="zeebe-simple-monitor",name="brokerChannelExecutor",} 0.0
executor_active_threads{application="zeebe-simple-monitor",name="clientOutboundChannelExecutor",} 0.0
# HELP process_cpu_usage The "recent cpu usage" for the Java Virtual Machine process
# TYPE process_cpu_usage gauge
process_cpu_usage{application="zeebe-simple-monitor",} 0.003250087826663052
# HELP spring_data_repository_invocations_seconds_max Duration of repository invocations
# TYPE spring_data_repository_invocations_seconds_max gauge
spring_data_repository_invocations_seconds_max{application="zeebe-simple-monitor",exception="None",method="findById",repository="HazelcastConfigRepository",state="SUCCESS",} 0.0191915
# HELP spring_data_repository_invocations_seconds Duration of repository invocations
# TYPE spring_data_repository_invocations_seconds summary
spring_data_repository_invocations_seconds_count{application="zeebe-simple-monitor",exception="None",method="findById",repository="HazelcastConfigRepository",state="SUCCESS",} 1.0
spring_data_repository_invocations_seconds_sum{application="zeebe-simple-monitor",exception="None",method="findById",repository="HazelcastConfigRepository",state="SUCCESS",} 0.0191915
# HELP tomcat_sessions_alive_max_seconds  
# TYPE tomcat_sessions_alive_max_seconds gauge
tomcat_sessions_alive_max_seconds{application="zeebe-simple-monitor",} 0.0
# HELP jvm_gc_memory_allocated_bytes_total Incremented for an increase in the size of the (young) heap memory pool after one GC to before the next
# TYPE jvm_gc_memory_allocated_bytes_total counter
jvm_gc_memory_allocated_bytes_total{application="zeebe-simple-monitor",} 4.46693376E8
# HELP hikaricp_connections_min Min connections
# TYPE hikaricp_connections_min gauge
hikaricp_connections_min{application="zeebe-simple-monitor",pool="HikariPool-1",} 10.0
# HELP process_files_max_files The maximum file descriptor count
# TYPE process_files_max_files gauge
process_files_max_files{application="zeebe-simple-monitor",} 10240.0
# HELP hikaricp_connections_acquire_seconds Connection acquire time
# TYPE hikaricp_connections_acquire_seconds summary
hikaricp_connections_acquire_seconds_count{application="zeebe-simple-monitor",pool="HikariPool-1",} 5.0
hikaricp_connections_acquire_seconds_sum{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.005
# HELP hikaricp_connections_acquire_seconds_max Connection acquire time
# TYPE hikaricp_connections_acquire_seconds_max gauge
hikaricp_connections_acquire_seconds_max{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.004
# HELP hikaricp_connections_idle Idle connections
# TYPE hikaricp_connections_idle gauge
hikaricp_connections_idle{application="zeebe-simple-monitor",pool="HikariPool-1",} 10.0
# HELP executor_pool_max_threads The maximum allowed number of threads in the pool
# TYPE executor_pool_max_threads gauge
executor_pool_max_threads{application="zeebe-simple-monitor",name="clientInboundChannelExecutor",} 2.147483647E9
executor_pool_max_threads{application="zeebe-simple-monitor",name="messageBrokerTaskScheduler",} 2.147483647E9
executor_pool_max_threads{application="zeebe-simple-monitor",name="asyncExecutor",} 1.0
executor_pool_max_threads{application="zeebe-simple-monitor",name="brokerChannelExecutor",} 1.0
executor_pool_max_threads{application="zeebe-simple-monitor",name="clientOutboundChannelExecutor",} 2.147483647E9
# HELP jvm_buffer_memory_used_bytes An estimate of the memory that the Java virtual machine is using for this buffer pool
# TYPE jvm_buffer_memory_used_bytes gauge
jvm_buffer_memory_used_bytes{application="zeebe-simple-monitor",id="mapped",} 0.0
jvm_buffer_memory_used_bytes{application="zeebe-simple-monitor",id="mapped - 'non-volatile memory'",} 0.0
jvm_buffer_memory_used_bytes{application="zeebe-simple-monitor",id="direct",} 4389069.0
# HELP hikaricp_connections_creation_seconds_max Connection creation time
# TYPE hikaricp_connections_creation_seconds_max gauge
hikaricp_connections_creation_seconds_max{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.001
# HELP hikaricp_connections_creation_seconds Connection creation time
# TYPE hikaricp_connections_creation_seconds summary
hikaricp_connections_creation_seconds_count{application="zeebe-simple-monitor",pool="HikariPool-1",} 9.0
hikaricp_connections_creation_seconds_sum{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.005
# HELP jvm_classes_loaded_classes The number of classes that are currently loaded in the Java virtual machine
# TYPE jvm_classes_loaded_classes gauge
jvm_classes_loaded_classes{application="zeebe-simple-monitor",} 17560.0
# HELP tomcat_sessions_active_max_sessions  
# TYPE tomcat_sessions_active_max_sessions gauge
tomcat_sessions_active_max_sessions{application="zeebe-simple-monitor",} 0.0
# HELP jvm_threads_daemon_threads The current number of live daemon threads
# TYPE jvm_threads_daemon_threads gauge
jvm_threads_daemon_threads{application="zeebe-simple-monitor",} 30.0
# HELP logback_events_total Number of events that made it to the logs
# TYPE logback_events_total counter
logback_events_total{application="zeebe-simple-monitor",level="error",} 0.0
logback_events_total{application="zeebe-simple-monitor",level="debug",} 0.0
logback_events_total{application="zeebe-simple-monitor",level="warn",} 0.0
logback_events_total{application="zeebe-simple-monitor",level="info",} 4.0
logback_events_total{application="zeebe-simple-monitor",level="trace",} 0.0
# HELP tomcat_sessions_created_sessions_total  
# TYPE tomcat_sessions_created_sessions_total counter
tomcat_sessions_created_sessions_total{application="zeebe-simple-monitor",} 0.0
# HELP hikaricp_connections_max Max connections
# TYPE hikaricp_connections_max gauge
hikaricp_connections_max{application="zeebe-simple-monitor",pool="HikariPool-1",} 10.0
# HELP jvm_memory_max_bytes The maximum amount of memory in bytes that can be used for memory management
# TYPE jvm_memory_max_bytes gauge
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Old Gen",} 4.294967296E9
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Eden Space",} -1.0
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="nonheap",id="Metaspace",} -1.0
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Survivor Space",} -1.0
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'profiled nmethods'",} 1.22896384E8
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="nonheap",id="Compressed Class Space",} 1.073741824E9
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'non-nmethods'",} 5849088.0
jvm_memory_max_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'non-profiled nmethods'",} 1.22912768E8
# HELP process_start_time_seconds Start time of the process since unix epoch.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{application="zeebe-simple-monitor",} 1.660645782547E9
# HELP jdbc_connections_max Maximum number of active connections that can be allocated at the same time.
# TYPE jdbc_connections_max gauge
jdbc_connections_max{application="zeebe-simple-monitor",name="dataSource",} 10.0
# HELP http_server_requests_seconds Duration of HTTP server request handling
# TYPE http_server_requests_seconds summary
http_server_requests_seconds_count{application="zeebe-simple-monitor",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/health",} 1.0
http_server_requests_seconds_sum{application="zeebe-simple-monitor",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/health",} 2.901357375
http_server_requests_seconds_count{application="zeebe-simple-monitor",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 5.0
http_server_requests_seconds_sum{application="zeebe-simple-monitor",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 0.129460209
# HELP http_server_requests_seconds_max Duration of HTTP server request handling
# TYPE http_server_requests_seconds_max gauge
http_server_requests_seconds_max{application="zeebe-simple-monitor",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/health",} 2.901357375
http_server_requests_seconds_max{application="zeebe-simple-monitor",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 0.091094542
# HELP system_cpu_count The number of processors available to the Java virtual machine
# TYPE system_cpu_count gauge
system_cpu_count{application="zeebe-simple-monitor",} 8.0
# HELP jvm_threads_states_threads The current number of threads
# TYPE jvm_threads_states_threads gauge
jvm_threads_states_threads{application="zeebe-simple-monitor",state="waiting",} 28.0
jvm_threads_states_threads{application="zeebe-simple-monitor",state="blocked",} 0.0
jvm_threads_states_threads{application="zeebe-simple-monitor",state="new",} 0.0
jvm_threads_states_threads{application="zeebe-simple-monitor",state="terminated",} 0.0
jvm_threads_states_threads{application="zeebe-simple-monitor",state="runnable",} 17.0
jvm_threads_states_threads{application="zeebe-simple-monitor",state="timed-waiting",} 12.0
# HELP executor_queued_tasks The approximate number of tasks that are queued for execution
# TYPE executor_queued_tasks gauge
executor_queued_tasks{application="zeebe-simple-monitor",name="clientInboundChannelExecutor",} 0.0
executor_queued_tasks{application="zeebe-simple-monitor",name="messageBrokerTaskScheduler",} 0.0
executor_queued_tasks{application="zeebe-simple-monitor",name="asyncExecutor",} 0.0
executor_queued_tasks{application="zeebe-simple-monitor",name="brokerChannelExecutor",} 0.0
executor_queued_tasks{application="zeebe-simple-monitor",name="clientOutboundChannelExecutor",} 0.0
# HELP application_started_time_seconds Time taken (ms) to start the application
# TYPE application_started_time_seconds gauge
application_started_time_seconds{application="zeebe-simple-monitor",main_application_class="io.zeebe.monitor.ZeebeSimpleMonitorApp",} 5.987
# HELP process_files_open_files The open file descriptor count
# TYPE process_files_open_files gauge
process_files_open_files{application="zeebe-simple-monitor",} 196.0
# HELP jvm_memory_used_bytes The amount of used memory
# TYPE jvm_memory_used_bytes gauge
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Old Gen",} 5.8003968E7
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Eden Space",} 2.3068672E7
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="nonheap",id="Metaspace",} 9.1119384E7
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="heap",id="G1 Survivor Space",} 1.2582912E7
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'profiled nmethods'",} 1.4274432E7
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="nonheap",id="Compressed Class Space",} 1.2332744E7
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'non-nmethods'",} 1390592.0
jvm_memory_used_bytes{application="zeebe-simple-monitor",area="nonheap",id="CodeHeap 'non-profiled nmethods'",} 3610368.0
# HELP executor_queue_remaining_tasks The number of additional elements that this queue can ideally accept without blocking
# TYPE executor_queue_remaining_tasks gauge
executor_queue_remaining_tasks{application="zeebe-simple-monitor",name="clientInboundChannelExecutor",} 2.147483647E9
executor_queue_remaining_tasks{application="zeebe-simple-monitor",name="messageBrokerTaskScheduler",} 2.147483647E9
executor_queue_remaining_tasks{application="zeebe-simple-monitor",name="asyncExecutor",} 32.0
executor_queue_remaining_tasks{application="zeebe-simple-monitor",name="brokerChannelExecutor",} 0.0
executor_queue_remaining_tasks{application="zeebe-simple-monitor",name="clientOutboundChannelExecutor",} 2.147483647E9
# HELP jvm_threads_live_threads The current number of live threads including both daemon and non-daemon threads
# TYPE jvm_threads_live_threads gauge
jvm_threads_live_threads{application="zeebe-simple-monitor",} 57.0
# HELP disk_free_bytes Usable space for path
# TYPE disk_free_bytes gauge
disk_free_bytes{application="zeebe-simple-monitor",path="/Users/tgdmadas/Documents/15_unicorn/playground/zeebe-simple-monitor-prometheus/zeebe-simple-monitor/.",} 6.7943428096E10
# HELP disk_total_bytes Total space for path
# TYPE disk_total_bytes gauge
disk_total_bytes{application="zeebe-simple-monitor",path="/Users/tgdmadas/Documents/15_unicorn/playground/zeebe-simple-monitor-prometheus/zeebe-simple-monitor/.",} 4.94384795648E11
# HELP jvm_gc_max_data_size_bytes Max size of long-lived heap memory pool
# TYPE jvm_gc_max_data_size_bytes gauge
jvm_gc_max_data_size_bytes{application="zeebe-simple-monitor",} 4.294967296E9
# HELP jvm_gc_live_data_size_bytes Size of long-lived heap memory pool after reclamation
# TYPE jvm_gc_live_data_size_bytes gauge
jvm_gc_live_data_size_bytes{application="zeebe-simple-monitor",} 0.0
# HELP jvm_gc_memory_promoted_bytes_total Count of positive increases in the size of the old generation memory pool before GC to after GC
# TYPE jvm_gc_memory_promoted_bytes_total counter
jvm_gc_memory_promoted_bytes_total{application="zeebe-simple-monitor",} 4.5259776E7
# HELP tomcat_sessions_expired_sessions_total  
# TYPE tomcat_sessions_expired_sessions_total counter
tomcat_sessions_expired_sessions_total{application="zeebe-simple-monitor",} 0.0
# HELP hikaricp_connections Total connections
# TYPE hikaricp_connections gauge
hikaricp_connections{application="zeebe-simple-monitor",pool="HikariPool-1",} 10.0
# HELP executor_pool_size_threads The current number of threads in the pool
# TYPE executor_pool_size_threads gauge
executor_pool_size_threads{application="zeebe-simple-monitor",name="clientInboundChannelExecutor",} 0.0
executor_pool_size_threads{application="zeebe-simple-monitor",name="messageBrokerTaskScheduler",} 0.0
executor_pool_size_threads{application="zeebe-simple-monitor",name="asyncExecutor",} 0.0
executor_pool_size_threads{application="zeebe-simple-monitor",name="brokerChannelExecutor",} 0.0
executor_pool_size_threads{application="zeebe-simple-monitor",name="clientOutboundChannelExecutor",} 0.0
# HELP hikaricp_connections_pending Pending threads
# TYPE hikaricp_connections_pending gauge
hikaricp_connections_pending{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.0
# HELP tomcat_sessions_rejected_sessions_total  
# TYPE tomcat_sessions_rejected_sessions_total counter
tomcat_sessions_rejected_sessions_total{application="zeebe-simple-monitor",} 0.0
# HELP jvm_classes_unloaded_classes_total The total number of classes unloaded since the Java virtual machine has started execution
# TYPE jvm_classes_unloaded_classes_total counter
jvm_classes_unloaded_classes_total{application="zeebe-simple-monitor",} 0.0
# HELP jdbc_connections_min Minimum number of idle connections in the pool.
# TYPE jdbc_connections_min gauge
jdbc_connections_min{application="zeebe-simple-monitor",name="dataSource",} 10.0
# HELP jvm_buffer_total_capacity_bytes An estimate of the total capacity of the buffers in this pool
# TYPE jvm_buffer_total_capacity_bytes gauge
jvm_buffer_total_capacity_bytes{application="zeebe-simple-monitor",id="mapped",} 0.0
jvm_buffer_total_capacity_bytes{application="zeebe-simple-monitor",id="mapped - 'non-volatile memory'",} 0.0
jvm_buffer_total_capacity_bytes{application="zeebe-simple-monitor",id="direct",} 4389068.0
# HELP system_cpu_usage The "recent cpu usage" of the system the application is running in
# TYPE system_cpu_usage gauge
system_cpu_usage{application="zeebe-simple-monitor",} 0.5819672131147541
# HELP jvm_memory_usage_after_gc_percent The percentage of long-lived heap pool used after the last GC event, in the range [0..1]
# TYPE jvm_memory_usage_after_gc_percent gauge
jvm_memory_usage_after_gc_percent{application="zeebe-simple-monitor",area="heap",pool="long-lived",} 0.013505101203918457
# HELP hikaricp_connections_usage_seconds Connection usage time
# TYPE hikaricp_connections_usage_seconds summary
hikaricp_connections_usage_seconds_count{application="zeebe-simple-monitor",pool="HikariPool-1",} 5.0
hikaricp_connections_usage_seconds_sum{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.099
# HELP hikaricp_connections_usage_seconds_max Connection usage time
# TYPE hikaricp_connections_usage_seconds_max gauge
hikaricp_connections_usage_seconds_max{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.037
# HELP tomcat_sessions_active_current_sessions  
# TYPE tomcat_sessions_active_current_sessions gauge
tomcat_sessions_active_current_sessions{application="zeebe-simple-monitor",} 0.0
# HELP executor_pool_core_threads The core number of threads for the pool
# TYPE executor_pool_core_threads gauge
executor_pool_core_threads{application="zeebe-simple-monitor",name="clientInboundChannelExecutor",} 16.0
executor_pool_core_threads{application="zeebe-simple-monitor",name="messageBrokerTaskScheduler",} 8.0
executor_pool_core_threads{application="zeebe-simple-monitor",name="asyncExecutor",} 1.0
executor_pool_core_threads{application="zeebe-simple-monitor",name="brokerChannelExecutor",} 0.0
executor_pool_core_threads{application="zeebe-simple-monitor",name="clientOutboundChannelExecutor",} 16.0
# HELP jvm_gc_pause_seconds Time spent in GC pause
# TYPE jvm_gc_pause_seconds summary
jvm_gc_pause_seconds_count{action="end of minor GC",application="zeebe-simple-monitor",cause="G1 Evacuation Pause",} 10.0
jvm_gc_pause_seconds_sum{action="end of minor GC",application="zeebe-simple-monitor",cause="G1 Evacuation Pause",} 0.099
jvm_gc_pause_seconds_count{action="end of minor GC",application="zeebe-simple-monitor",cause="Metadata GC Threshold",} 1.0
jvm_gc_pause_seconds_sum{action="end of minor GC",application="zeebe-simple-monitor",cause="Metadata GC Threshold",} 0.007
# HELP jvm_gc_pause_seconds_max Time spent in GC pause
# TYPE jvm_gc_pause_seconds_max gauge
jvm_gc_pause_seconds_max{action="end of minor GC",application="zeebe-simple-monitor",cause="G1 Evacuation Pause",} 0.026
jvm_gc_pause_seconds_max{action="end of minor GC",application="zeebe-simple-monitor",cause="Metadata GC Threshold",} 0.007
# HELP hikaricp_connections_active Active connections
# TYPE hikaricp_connections_active gauge
hikaricp_connections_active{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.0
# HELP jvm_gc_overhead_percent An approximation of the percent of CPU time used by GC activities over the last lookback period or since monitoring began, whichever is shorter, in the range [0..1]
# TYPE jvm_gc_overhead_percent gauge
jvm_gc_overhead_percent{application="zeebe-simple-monitor",} 0.003070335947433531
# HELP system_load_average_1m The sum of the number of runnable entities queued to available processors and the number of runnable entities running on the available processors averaged over a period of time
# TYPE system_load_average_1m gauge
system_load_average_1m{application="zeebe-simple-monitor",} 5.333984375
# HELP application_ready_time_seconds Time taken (ms) for the application to be ready to service requests
# TYPE application_ready_time_seconds gauge
application_ready_time_seconds{application="zeebe-simple-monitor",main_application_class="io.zeebe.monitor.ZeebeSimpleMonitorApp",} 5.993
# HELP hikaricp_connections_timeout_total Connection timeout total count
# TYPE hikaricp_connections_timeout_total counter
hikaricp_connections_timeout_total{application="zeebe-simple-monitor",pool="HikariPool-1",} 0.0
```

</details>


closes #433