### PR TITLE
build: fixes Maven warnings (duplicate entry and missing version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,6 @@
         </dependency>
 
         <dependency>
-           <groupId>org.springframework.boot</groupId>
-           <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-
-        <dependency>
            <groupId>io.micrometer</groupId>
            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
@@ -251,6 +246,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.0</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
just a minor fix, which tackles these Maven warnings ...

```
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework.boot:spring-boot-starter-actuator:jar -> duplicate declaration of version (?) @ line 115, column 21

[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 251, column 21
```