### PR TITLE
feat(ui): incident view filtering by process id and time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,12 +169,12 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>4.6.0-1</version>
+            <version>4.6.2</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>popper.js</artifactId>
-            <version>1.16.0</version>
+            <version>1.16.1-lts</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,20 @@
         </dependency>
 
         <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+            <version>5.0.0</version>
+            <classifier>jpa</classifier>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-jpa</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
             <version>${version.hazelcast}</version>
@@ -235,6 +249,30 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.13</version>
+                </plugin>
+                <!--Plugin for query-dsl-->
+                <plugin>
+                    <groupId>com.mysema.maven</groupId>
+                    <artifactId>apt-maven-plugin</artifactId>
+                    <version>1.1.3</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>process</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>io.zeebe.monitor.entity.**</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <outputDirectory>target/generated-sources/annotations</outputDirectory>
+                        <processors>
+                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+                        </processors>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/java/io/zeebe/monitor/querydsl/IncidentEntityPredicatesBuilder.java
+++ b/src/main/java/io/zeebe/monitor/querydsl/IncidentEntityPredicatesBuilder.java
@@ -6,14 +6,19 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
 import io.zeebe.monitor.entity.QIncidentEntity;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class IncidentEntityPredicatesBuilder {
   final PathBuilder<QIncidentEntity> pathBuilder = new PathBuilder<>(QIncidentEntity.class, QIncidentEntity.incidentEntity.getMetadata());
-  private List<Predicate> predicates = new ArrayList<>();
+  private final List<Predicate> predicates = new ArrayList<>();
 
   public IncidentEntityPredicatesBuilder onlyUnresolved() {
     predicates.add(pathBuilder.getNumber("resolved", Long.class).isNull());
@@ -34,11 +39,38 @@ public class IncidentEntityPredicatesBuilder {
     return this;
   }
 
-  public BooleanExpression build() {
+  public IncidentEntityPredicatesBuilder createdAfter(String timestamp) {
+    if (!isEmpty(timestamp)) {
+      final Optional<Long> created = parseIsoToUtcMillis(timestamp);
+      created.ifPresent(utcMillis -> predicates.add(pathBuilder.getNumber("created", Long.class).goe(utcMillis)));
+    }
+    return this;
+  }
+
+  public IncidentEntityPredicatesBuilder createdBefore(String timestamp) {
+    if (!isEmpty(timestamp)) {
+      final Optional<Long> created = parseIsoToUtcMillis(timestamp);
+      created.ifPresent(utcMillis -> predicates.add(pathBuilder.getNumber("created", Long.class).loe(utcMillis)));
+    }
+    return this;
+  }
+
+  public Predicate build() {
     BooleanExpression result = Expressions.asBoolean(true).isTrue();
     for (Predicate predicate : predicates) {
       result = result.and(predicate);
     }
     return result;
+  }
+
+  private Optional<Long> parseIsoToUtcMillis(String timestamp) {
+    try {
+      final ZonedDateTime zonedDateTime = ZonedDateTime.from(DateTimeFormatter.ISO_DATE_TIME.parse(timestamp));
+      final long utcMillis = zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toInstant().toEpochMilli();
+      return Optional.of(utcMillis);
+    } catch (DateTimeParseException ignore) {
+      // ignore
+    }
+    return Optional.empty();
   }
 }

--- a/src/main/java/io/zeebe/monitor/querydsl/IncidentEntityPredicatesBuilder.java
+++ b/src/main/java/io/zeebe/monitor/querydsl/IncidentEntityPredicatesBuilder.java
@@ -1,0 +1,44 @@
+package io.zeebe.monitor.querydsl;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.PathBuilder;
+import io.zeebe.monitor.entity.QIncidentEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+public class IncidentEntityPredicatesBuilder {
+  final PathBuilder<QIncidentEntity> pathBuilder = new PathBuilder<>(QIncidentEntity.class, QIncidentEntity.incidentEntity.getMetadata());
+  private List<Predicate> predicates = new ArrayList<>();
+
+  public IncidentEntityPredicatesBuilder onlyUnresolved() {
+    predicates.add(pathBuilder.getNumber("resolved", Long.class).isNull());
+    return this;
+  }
+
+  public IncidentEntityPredicatesBuilder withProcessId(String processId) {
+    if (!isEmpty(processId)) {
+      predicates.add(pathBuilder.getString("bpmnProcessId").containsIgnoreCase(processId));
+    }
+    return this;
+  }
+
+  public IncidentEntityPredicatesBuilder withErrorType(String errorType) {
+    if (!isEmpty(errorType)) {
+      predicates.add(pathBuilder.getString("errorType").containsIgnoreCase(errorType));
+    }
+    return this;
+  }
+
+  public BooleanExpression build() {
+    BooleanExpression result = Expressions.asBoolean(true).isTrue();
+    for (Predicate predicate : predicates) {
+      result = result.and(predicate);
+    }
+    return result;
+  }
+}

--- a/src/main/java/io/zeebe/monitor/repository/IncidentRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/IncidentRepository.java
@@ -16,15 +16,11 @@
 package io.zeebe.monitor.repository;
 
 import io.zeebe.monitor.entity.IncidentEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface IncidentRepository extends PagingAndSortingRepository<IncidentEntity, Long> {
+public interface IncidentRepository extends PagingAndSortingRepository<IncidentEntity, Long>, QuerydslPredicateExecutor<IncidentEntity> {
 
   Iterable<IncidentEntity> findByProcessInstanceKey(long processInstanceKey);
 
-  Page<IncidentEntity> findByResolvedIsNull(Pageable pageable);
-
-  long countByResolvedIsNull();
 }

--- a/src/main/java/io/zeebe/monitor/rest/IncidentsViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/IncidentsViewController.java
@@ -1,6 +1,6 @@
 package io.zeebe.monitor.rest;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.Predicate;
 import io.zeebe.monitor.entity.IncidentEntity;
 import io.zeebe.monitor.querydsl.IncidentEntityPredicatesBuilder;
 import io.zeebe.monitor.repository.IncidentRepository;
@@ -28,15 +28,19 @@ public class IncidentsViewController extends AbstractViewController {
   public String incidentList(final Map<String, Object> model,
                              final Pageable pageable,
                              @RequestParam(required = false) String bpmnProcessId,
-                             @RequestParam(required = false) String errorType) {
+                             @RequestParam(required = false) String errorType,
+                             @RequestParam(required = false) String createdAfter,
+                             @RequestParam(required = false) String createdBefore) {
 
-    final IncidentEntityPredicatesBuilder predicatesBuilder = new IncidentEntityPredicatesBuilder();
-    predicatesBuilder.onlyUnresolved();
-    predicatesBuilder.withProcessId(bpmnProcessId);
-    predicatesBuilder.withErrorType(errorType);
-    final BooleanExpression predicates = predicatesBuilder.build();
+    final Predicate predicate = new IncidentEntityPredicatesBuilder()
+        .onlyUnresolved()
+        .withProcessId(bpmnProcessId)
+        .withErrorType(errorType)
+        .createdAfter(createdAfter)
+        .createdBefore(createdBefore)
+        .build();
 
-    final Page<IncidentEntity> dtos = incidentRepository.findAll(predicates, pageable);
+    final Page<IncidentEntity> dtos = incidentRepository.findAll(predicate, pageable);
     final List<IncidentListDto> incidents = new ArrayList<>();
     for (final IncidentEntity incidentEntity : dtos) {
       final IncidentListDto dto = toDto(incidentEntity);

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -729,3 +729,16 @@ function onBpmnDownloadClicked(){
 })();
 
 // --------------------------------------------------------------------
+
+/**
+ * Takes a value from the search query parameters and sets the value attribute for the specified element.
+ * @param elementId mandatory, the element's ID
+ * @param paramName mandatory, the name of the query parameter
+ */
+function bindQueryParamToElement(elementId, paramName) {
+    'use strict';
+    let params = new URLSearchParams(window.location.search)
+    if (params.get(paramName) !== null) {
+        document.getElementById(elementId).setAttribute("value", params.get(paramName))
+    }
+}

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -649,25 +649,33 @@ function listPage(pageElement, page, size) {
     }
 }
 
-function listSort(sortProperty, sortElement) {
-    let sortAsc = "sort=" + sortProperty + ",asc"
-    let sortDesc = "sort=" + sortProperty + ",desc"
-
+function listSort(sortProperty, elementId) {
+    let sortAsc = "sort=" + sortProperty + ",asc";
+    let sortDesc = "sort=" + sortProperty + ",desc";
+    let elementNode = document.getElementById(elementId);
     let search = window.location.search
+    let sortParamRegEx = /sort=\w+,\w+/;
+
     if(search.includes(sortAsc)) {
-        let withReverseOrder = search.replace(sortAsc, sortDesc)
-        document.getElementById(sortElement).href = withReverseOrder;
-        document.getElementById(sortElement).innerHTML = IMAGE_ARROW_DOWN;
+        let withReverseOrder = search.replace(sortAsc, sortDesc);
+        elementNode.href = withReverseOrder;
+        elementNode.innerHTML = IMAGE_ARROW_DOWN;
     } else if(search.includes(sortDesc)) {
-        let withReverseOrder = search.replace(sortDesc, sortAsc)
-        document.getElementById(sortElement).href = withReverseOrder
-        document.getElementById(sortElement).innerHTML = IMAGE_ARROW_UP;
+        let withReverseOrder = search.replace(sortDesc, sortAsc);
+        elementNode.href = withReverseOrder;
+        elementNode.innerHTML = IMAGE_ARROW_UP;
     } else if(search) {
-        document.getElementById(sortElement).href = search + "&" + sortDesc
-        document.getElementById(sortElement).innerHTML = IMAGE_ARROW_DOWN;
+        if (sortParamRegEx.test(window.location.search)) {
+            // sort param exists already and will be replaced
+            elementNode.href = search.replace(sortParamRegEx, sortDesc)
+        } else {
+            // no sort param exists and will be appended
+            elementNode.href = search + "&" + sortDesc;
+        }
+        elementNode.innerHTML = IMAGE_ARROW_DOWN;
     } else {
-        document.getElementById(sortElement).href = "?" + sortDesc
-        document.getElementById(sortElement).innerHTML = IMAGE_ARROW_UP;
+        elementNode.href = "?" + sortDesc;
+        elementNode.innerHTML = IMAGE_ARROW_UP;
     }
 }
 

--- a/src/main/resources/templates/incident-list-view.html
+++ b/src/main/resources/templates/incident-list-view.html
@@ -17,6 +17,19 @@
                 <div class="col-auto">
                     <div class="input-group mb-2">
                         <input type="text" class="form-control" id="filter-created-after" name="createdAfter" placeholder="created after" style="width: 15em">
+                        <div class="btn-group dropleft">
+                            <button id="dropdownMenuButton" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <svg class="bi" width="12" height="12" fill="silver"><use xlink:href="/img/bootstrap-icons.svg#clock-history"/></svg>
+                            </button>
+                            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                <a class="dropdown-item" id="last-7-days" href="#">last 7 days</a>
+                                <a class="dropdown-item" id="last-24-hours" href="#">last 24 hours</a>
+                                <a class="dropdown-item" id="last-12-hours" href="#">last 12 hours</a>
+                                <a class="dropdown-item" id="last-6-hours" href="#">last 6 hours</a>
+                                <a class="dropdown-item" id="last-1-hour" href="#">last 1 hour</a>
+                                <a class="dropdown-item" id="last-10-minutes" href="#">last 10 minutes</a>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="col-auto">
@@ -95,6 +108,22 @@
                 bindQueryParamToElement("filter-error-type", "errorType");
                 bindQueryParamToElement("filter-created-after", "createdAfter");
                 bindQueryParamToElement("filter-created-before", "createdBefore");
+            }, false);
+            document.addEventListener('DOMContentLoaded', function() {
+                function createLastTimeHandler(timeDiff) {
+                    return function() {
+                        'use strict';
+                        let past = new Date().getTime() - timeDiff;
+                        let newVal = new Date(past).toISOString();
+                        document.getElementById("filter-created-after").setAttribute("value", newVal);
+                    }
+                }
+                $("#last-7-days").click(createLastTimeHandler(1000*60*60*24*7));
+                $("#last-24-hours").click(createLastTimeHandler(1000*60*60*24));
+                $("#last-12-hours").click(createLastTimeHandler(1000*60*60*12));
+                $("#last-6-hours").click(createLastTimeHandler(1000*60*60*6));
+                $("#last-1-hour").click(createLastTimeHandler(1000*60*60));
+                $("#last-10-minutes").click(createLastTimeHandler(1000*60*10));
             }, false);
         </script>
     </div>

--- a/src/main/resources/templates/incident-list-view.html
+++ b/src/main/resources/templates/incident-list-view.html
@@ -2,27 +2,52 @@
 
 <div class="row">
     <div class="col-md-12">
+        <form method="get">
+            <div class="form-row align-items-center">
+                <div class="col-auto">
+                    <div class="input-group mb-2">
+                        <input type="text" class="form-control" id="filter-process-id" name="bpmnProcessId" placeholder="Process ID">
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <div class="input-group mb-2">
+                        <input type="text" class="form-control" id="filter-error-type" name="errorType" placeholder="Error Type">
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-primary mb-2"><svg class="bi" width="12" height="12" fill="silver"><use xlink:href="/img/bootstrap-icons.svg#funnel"/></svg> Filter</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
 
+<div class="row">
+    <div class="col-md-12">
         <span>{{count}} open incidents</span>
 
         <table class="table table-striped">
             <thead>
-            <th>Incident Key</th>
-            <th>Process Instance Key</th>
-            <th>BPMN process id
-                <a id="bpmn-process-id" href="#" class="badge badge-secondary" data-toggle="tooltip" data-placement="top"
-                                          title="Sort by BPMN process id"></a>
-            </th>
-            <th>Process Definition Key</th>
-            <th>Error Type
-                <a id="error-type" href="#" class="badge badge-secondary" data-toggle="tooltip" data-placement="top"
-                             title="Sort by Error Type"></a>
-            </th>
-            <th>State</th>
-            <th>Created Time
-                <a id="created-time" href="#" class="badge badge-secondary" data-toggle="tooltip" data-placement="top"
-                   title="Sort by Created Time"></a>
-            </th>
+                <tr>
+                    <th>Incident Key</th>
+                    <th>Process Instance Key</th>
+                    <th>BPMN process id
+                        <a id="bpmn-process-id" href="#" class="badge badge-secondary" data-toggle="tooltip"
+                           data-placement="top"
+                           title="Sort by BPMN process id"></a>
+                    </th>
+                    <th>Process Definition Key</th>
+                    <th>Error Type
+                        <a id="error-type" href="#" class="badge badge-secondary" data-toggle="tooltip" data-placement="top"
+                           title="Sort by Error Type"></a>
+                    </th>
+                    <th>State</th>
+                    <th>Created Time
+                        <a id="created-time" href="#" class="badge badge-secondary" data-toggle="tooltip"
+                           data-placement="top"
+                           title="Sort by Created Time"></a>
+                    </th>
+                </tr>
             </thead>
 
             {{#incidents}}
@@ -57,6 +82,12 @@
             }, false);
         </script>
 
+        <script type="application/javascript">
+            document.addEventListener('DOMContentLoaded', function() {
+                bindQueryParamToElement("filter-process-id", "bpmnProcessId");
+                bindQueryParamToElement("filter-error-type", "errorType");
+            }, false);
+        </script>
     </div>
 </div>
 

--- a/src/main/resources/templates/incident-list-view.html
+++ b/src/main/resources/templates/incident-list-view.html
@@ -6,12 +6,22 @@
             <div class="form-row align-items-center">
                 <div class="col-auto">
                     <div class="input-group mb-2">
-                        <input type="text" class="form-control" id="filter-process-id" name="bpmnProcessId" placeholder="Process ID">
+                        <input type="text" class="form-control" id="filter-process-id" name="bpmnProcessId" placeholder="process id" style="width: 15em">
                     </div>
                 </div>
                 <div class="col-auto">
                     <div class="input-group mb-2">
-                        <input type="text" class="form-control" id="filter-error-type" name="errorType" placeholder="Error Type">
+                        <input type="text" class="form-control" id="filter-error-type" name="errorType" placeholder="error type" style="width: 15em">
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <div class="input-group mb-2">
+                        <input type="text" class="form-control" id="filter-created-after" name="createdAfter" placeholder="created after" style="width: 15em">
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <div class="input-group mb-2">
+                        <input type="text" class="form-control" id="filter-created-before" name="createdBefore" placeholder="created before" style="width: 15em">
                     </div>
                 </div>
                 <div class="col-auto">
@@ -80,12 +90,11 @@
             document.addEventListener('DOMContentLoaded', function(){
                 listSort('created','created-time')
             }, false);
-        </script>
-
-        <script type="application/javascript">
             document.addEventListener('DOMContentLoaded', function() {
                 bindQueryParamToElement("filter-process-id", "bpmnProcessId");
                 bindQueryParamToElement("filter-error-type", "errorType");
+                bindQueryParamToElement("filter-created-after", "createdAfter");
+                bindQueryParamToElement("filter-created-before", "createdBefore");
             }, false);
         </script>
     </div>

--- a/src/main/resources/templates/incident-list-view.html
+++ b/src/main/resources/templates/incident-list-view.html
@@ -9,11 +9,20 @@
             <thead>
             <th>Incident Key</th>
             <th>Process Instance Key</th>
-            <th>BPMN process id</th>
+            <th>BPMN process id
+                <a id="bpmn-process-id" href="#" class="badge badge-secondary" data-toggle="tooltip" data-placement="top"
+                                          title="Sort by BPMN process id"></a>
+            </th>
             <th>Process Definition Key</th>
-            <th>Error Type</th>
+            <th>Error Type
+                <a id="error-type" href="#" class="badge badge-secondary" data-toggle="tooltip" data-placement="top"
+                             title="Sort by Error Type"></a>
+            </th>
             <th>State</th>
-            <th>Created Time</th>
+            <th>Created Time
+                <a id="created-time" href="#" class="badge badge-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Sort by Created Time"></a>
+            </th>
             </thead>
 
             {{#incidents}}
@@ -35,6 +44,18 @@
         </table>
 
         {{>components/table-pagination}}
+
+        <script type="application/javascript">
+            document.addEventListener('DOMContentLoaded', function(){
+                listSort('bpmnProcessId','bpmn-process-id')
+            }, false);
+            document.addEventListener('DOMContentLoaded', function(){
+                listSort('errorType','error-type')
+            }, false);
+            document.addEventListener('DOMContentLoaded', function(){
+                listSort('created','created-time')
+            }, false);
+        </script>
 
     </div>
 </div>

--- a/src/main/resources/templates/layout/footer.html
+++ b/src/main/resources/templates/layout/footer.html
@@ -4,7 +4,7 @@
 
 <!-- jQuery first, then Popper.js, then Bootstrap JS -->
 <script src="{{context-path}}webjars/jquery/jquery.min.js"></script>
-<script src="{{context-path}}webjars/popper.js/1.16.0/popper.min.js"></script>
+<script src="{{context-path}}webjars/popper.js/umd/popper.min.js"></script>
 <script src="{{context-path}}webjars/bootstrap/js/bootstrap.min.js"></script>
 
 <script src="{{context-path}}webjars/sockjs-client/sockjs.min.js"></script>


### PR DESCRIPTION
implements #438 

### Demo/Screenshot
![Screenshot 2022-10-05 at 16 45 13](https://user-images.githubusercontent.com/1189394/194090311-5cbaed39-892b-48d8-8bc2-3eff196e441c.png)

### noteworthy changes

- introducing new dependencies for QueryDSL
   - reasoning QueryDSL is well supported with the Spring JPA framework and eases the filtering of various attributes
- there's a bug fix for popper.js, since the import was broken (visible in JS console of Chrome, when clicking a drop-down menu, created with bootstrap and then there was the error message, that popper.js was missing)
- on-top of the ticket, I do introduce sorting of error type and process id to further assist in finding incidents