### PR TITLE
fix: RAW_BPMN_RESOURCE is not defined

### DIFF
--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -710,7 +710,7 @@ function onBpmnDownloadClicked(){
 
 (function checkIfBpmnExistsOrDisableDownloadButton() {
     'use strict';
-    if (RAW_BPMN_RESOURCE === 'WARNING-NO-XML-RESOURCE-FOUND') {
+    if (typeof RAW_BPMN_RESOURCE !== 'undefined' && RAW_BPMN_RESOURCE === 'WARNING-NO-XML-RESOURCE-FOUND') {
         var link = $('#bpmnDownloadLink');
         link.attr('title', 'BPMN definition not found or broken :-( ');
         link.removeAttr('href');


### PR DESCRIPTION
Just a minor thing, but since the app.js loads in every view, 
there was a JS error, when the screen model does not contain the required field, like in 'errors' for example.

Error was:
```
app.js:714 Uncaught ReferenceError: RAW_BPMN_RESOURCE is not defined
          at checkIfBpmnExistsOrDisableDownloadButton (app.js:714:5)
```