### PR TITLE
fix deprecation "expose-request-attributes"

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,8 @@ spring:
   mustache:
     prefix: classpath:/templates/
     suffix: .html
-    expose-request-attributes: true
+    servlet:
+      expose-request-attributes: true
 
   data:
     web:


### PR DESCRIPTION
because since spring-boot-autoconfigure:2.7.3, this field was moved

see https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/mustache/MustacheProperties.html