### PR TITLE
Add indices to ElementIndices to speed up queries

### DIFF
--- a/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
@@ -19,9 +19,10 @@ import javax.persistence.*;
 
 @Entity(name = "ELEMENT_INSTANCE")
 @Table(indexes = {
-    // performance reason, because we use it in the
-    // {@link io.zeebe.monitor.repository.ElementInstanceRepository#findByProcessInstanceKey(long)}
     @Index(name = "element_instance_processInstanceKeyIndex", columnList = "PROCESS_INSTANCE_KEY_"),
+    @Index(name = "element_instance_processDefinitionKeyIndex", columnList = "PROCESS_DEFINITION_KEY_"),
+    @Index(name = "element_instance_intentIndex", columnList = "INTENT_"),
+    @Index(name = "element_instance_bpmnElementTypeIndex", columnList = "BPMN_ELEMENT_TYPE_"),
 })
 public class ElementInstanceEntity {
 


### PR DESCRIPTION
I'd like to suggest additional indices on ElementInstance.

That table is queried from the monitor, and if you have some amount of data in the table, the query would run ages.

This PR adds some indices.

Fixes https://github.com/camunda-community-hub/zeebe-simple-monitor/issues/583, supersedes #584.