### PR TITLE
fix #659 implement a workaround to fix UnsupportedOperationException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,9 @@
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                        <configuration>
+                            <loaderImplementation>CLASSIC</loaderImplementation>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
+++ b/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
@@ -29,7 +29,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -38,8 +40,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = { WebMvcAutoConfiguration.class })
 @EnableScheduling
 @EnableAsync
 @EnableSpringDataWebSupport
@@ -111,6 +114,11 @@ public class ZeebeSimpleMonitorApp {
         }
       }
     };
+  }
+
+  @Bean(name = "mvcHandlerMappingIntrospector")
+  public HandlerMappingIntrospector mvcHandlerMappingIntrospector() {
+    return new HandlerMappingIntrospector();
   }
 
 }

--- a/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
+++ b/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -42,7 +41,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
-@SpringBootApplication(exclude = { WebMvcAutoConfiguration.class })
+@SpringBootApplication(exclude = {WebMvcAutoConfiguration.class})
 @EnableScheduling
 @EnableAsync
 @EnableSpringDataWebSupport
@@ -94,7 +93,7 @@ public class ZeebeSimpleMonitorApp {
           LOG.warn("can't determine version info from manifest, error: " + e.getMessage());
         }
       } else {
-          LOG.warn("MANIFEST.MF file not present in classpath; will use 'dev' as version information");
+        LOG.warn("MANIFEST.MF file not present in classpath; will use 'dev' as version information");
       }
     }
     final Attributes attributes = new Attributes();
@@ -120,5 +119,4 @@ public class ZeebeSimpleMonitorApp {
   public HandlerMappingIntrospector mvcHandlerMappingIntrospector() {
     return new HandlerMappingIntrospector();
   }
-
 }

--- a/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
+++ b/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
@@ -39,7 +39,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@SpringBootApplication(/*exclude = {WebMvcAutoConfiguration.class}*/ )
+@SpringBootApplication
 @EnableScheduling
 @EnableAsync
 @EnableSpringDataWebSupport

--- a/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
+++ b/src/main/java/io/zeebe/monitor/ZeebeSimpleMonitorApp.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -39,9 +38,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
-@SpringBootApplication(exclude = {WebMvcAutoConfiguration.class})
+@SpringBootApplication(/*exclude = {WebMvcAutoConfiguration.class}*/ )
 @EnableScheduling
 @EnableAsync
 @EnableSpringDataWebSupport
@@ -93,7 +91,8 @@ public class ZeebeSimpleMonitorApp {
           LOG.warn("can't determine version info from manifest, error: " + e.getMessage());
         }
       } else {
-        LOG.warn("MANIFEST.MF file not present in classpath; will use 'dev' as version information");
+        LOG.warn(
+            "MANIFEST.MF file not present in classpath; will use 'dev' as version information");
       }
     }
     final Attributes attributes = new Attributes();
@@ -113,10 +112,5 @@ public class ZeebeSimpleMonitorApp {
         }
       }
     };
-  }
-
-  @Bean(name = "mvcHandlerMappingIntrospector")
-  public HandlerMappingIntrospector mvcHandlerMappingIntrospector() {
-    return new HandlerMappingIntrospector();
   }
 }


### PR DESCRIPTION
this relates to the fact that Spring Boot 3.2.x did implement a new boot-loader code for uber jars.
See https://github.com/spring-projects/spring-boot/issues/38636 for details.