### PR TITLE
Export metrics about the import process

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The application imports the data from Zeebe using the [Hazelcast exporter](https
 
 ### Upgrading from a prior version
 
-See the [upgrade instructions](./UPGRADE.md).
+See the [upgrade instructions](UPGRADE.md).
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,15 @@ Refer to the [docker-compose file](docker/docker-compose.yml) for a sample confi
 Please be aware that when connecting to a Redis cluster you must activate
 the `useClusterClient` option.
 
+## Metrics
+The monitor exports a couple of metrics via the usual `/actuator/prometheus` endpoint.
+
+In addition to the default metrics that are available via Spring Boot, there are some metrics exported specific
+- for the import process (e.g. number of imported process instances)
+- Hazelcast's ringbuffer.
+
+All metrics are prefixed with `zeebemonitor_importer`.
+
 ## Code of Conduct
 
 This project adheres to the Contributor Covenant [Code of

--- a/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastImportService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastImportService.java
@@ -67,9 +67,7 @@ public class HazelcastImportService {
                             messageSubscriptionImporter::importMessageStartEventSubscription))
             .addErrorListener(errorImporter::importError)
             .postProcessListener(
-                sequence -> {
-                  hazelcastStateService.saveSequenceNumber(sequence);
-                });
+                sequence -> hazelcastStateService.saveSequenceNumber(sequence));
 
     final var lastSequence = hazelcastStateService.getLastSequenceNumber();
     if (lastSequence >= 0) {

--- a/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastImportService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastImportService.java
@@ -3,8 +3,6 @@ package io.zeebe.monitor.zeebe.hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.hazelcast.connect.java.ZeebeHazelcast;
-import io.zeebe.monitor.entity.HazelcastConfig;
-import io.zeebe.monitor.repository.HazelcastConfigRepository;
 import io.zeebe.monitor.zeebe.protobuf.importers.ErrorProtobufImporter;
 import io.zeebe.monitor.zeebe.protobuf.importers.IncidentProtobufImporter;
 import io.zeebe.monitor.zeebe.protobuf.importers.JobProtobufImporter;
@@ -30,7 +28,7 @@ public class HazelcastImportService {
   @Autowired private TimerProtobufImporter timerImporter;
   @Autowired private ErrorProtobufImporter errorImporter;
 
-  @Autowired private HazelcastConfigRepository hazelcastConfigRepository;
+  @Autowired private HazelcastStateService hazelcastStateService;
 
   public ZeebeHazelcast importFrom(final HazelcastInstance hazelcast) {
     final var builder =

--- a/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastImportService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastImportService.java
@@ -67,7 +67,7 @@ public class HazelcastImportService {
                             messageSubscriptionImporter::importMessageStartEventSubscription))
             .addErrorListener(errorImporter::importError)
             .postProcessListener(
-                sequence -> hazelcastStateService.saveSequenceNumber(sequence));
+                    hazelcastStateService::saveSequenceNumber);
 
     final var lastSequence = hazelcastStateService.getLastSequenceNumber();
     if (lastSequence >= 0) {

--- a/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastStateService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/hazelcast/HazelcastStateService.java
@@ -1,4 +1,4 @@
-package io.zeebe.monitor.zeebe.hazelcast.importers;
+package io.zeebe.monitor.zeebe.hazelcast;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ErrorProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ErrorProtobufImporter.java
@@ -11,12 +11,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class ErrorProtobufImporter {
 
+  private final ErrorRepository errorRepository;
   private final Counter counter;
 
-  private final ErrorRepository errorRepository;
-
   @Autowired
-  public ErrorHazelcastImporter(ErrorRepository errorRepository, MeterRegistry meterRegistry) {
+  public ErrorProtobufImporter(ErrorRepository errorRepository, MeterRegistry meterRegistry) {
     this.errorRepository = errorRepository;
 
     this.counter = Counter.builder("zeebemonitor_importer_error").description("number of processed errors").register(meterRegistry);

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ErrorProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ErrorProtobufImporter.java
@@ -1,5 +1,7 @@
 package io.zeebe.monitor.zeebe.protobuf.importers;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.ErrorEntity;
 import io.zeebe.monitor.repository.ErrorRepository;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class ErrorProtobufImporter {
 
   @Autowired private ErrorRepository errorRepository;
+  @Autowired private MeterRegistry meterRegistry;
 
   public void importError(final Schema.ErrorRecord record) {
 
@@ -32,5 +35,7 @@ public class ErrorProtobufImporter {
                 });
 
     errorRepository.save(entity);
+
+    Counter.builder("zeebemonitor_importer_error_imported").description("number of processed errors").register(meterRegistry).increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ErrorProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ErrorProtobufImporter.java
@@ -11,8 +11,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class ErrorProtobufImporter {
 
-  @Autowired private ErrorRepository errorRepository;
-  @Autowired private MeterRegistry meterRegistry;
+  private final Counter counter;
+
+  private final ErrorRepository errorRepository;
+
+  @Autowired
+  public ErrorHazelcastImporter(ErrorRepository errorRepository, MeterRegistry meterRegistry) {
+    this.errorRepository = errorRepository;
+
+    this.counter = Counter.builder("zeebemonitor_importer_error").description("number of processed errors").register(meterRegistry);
+  }
 
   public void importError(final Schema.ErrorRecord record) {
 
@@ -36,6 +44,6 @@ public class ErrorProtobufImporter {
 
     errorRepository.save(entity);
 
-    Counter.builder("zeebemonitor_importer_error_imported").description("number of processed errors").register(meterRegistry).increment();
+    counter.increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/HazelcastStateService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/HazelcastStateService.java
@@ -1,0 +1,62 @@
+package io.zeebe.monitor.zeebe.hazelcast.importers;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.zeebe.monitor.entity.HazelcastConfig;
+import io.zeebe.monitor.repository.HazelcastConfigRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The HazelcastStateService manages the current pointer of the Hazelcast import process.
+ *
+ * That pointer is required to read the next-relevant message from the RingBuffer
+ *
+ * Usually, that RingBuffer is read 1 by 1, but sometimes, the RingBuffer may overrun by the export process,
+ * and in that case, the Import process will set the sequence to the current position of the RingBuffer.
+ */
+@Component
+public class HazelcastStateService {
+
+  private final HazelcastConfigRepository hazelcastConfigRepository;
+  private final Counter sequenceCounter;
+
+  @Autowired
+  public HazelcastStateService(HazelcastConfigRepository hazelcastConfigRepository, MeterRegistry meterRegistry) {
+    this.hazelcastConfigRepository = hazelcastConfigRepository;
+
+    sequenceCounter = Counter.builder("zeebemonitor_importer_ringbuffer_sequences_read").
+            description("number of items read from Hazelcast's ringbuffer (sequence counter)").
+            register(meterRegistry);
+  }
+
+  public long getLastSequenceNumber() {
+    return getHazelcastConfig().getSequence();
+  }
+
+  @Transactional
+  public void saveSequenceNumber(long sequence) {
+    HazelcastConfig config = getHazelcastConfig();
+
+    long prev = config.getSequence();
+
+    config.setSequence(sequence);
+
+    hazelcastConfigRepository.save(config);
+
+    sequenceCounter.increment(sequence - prev);
+  }
+
+  private HazelcastConfig getHazelcastConfig() {
+    return hazelcastConfigRepository
+            .findById("cfg")
+            .orElseGet(
+                    () -> {
+                      final var config = new HazelcastConfig();
+                      config.setId("cfg");
+                      config.setSequence(-1);
+                      return config;
+                    });
+  }
+}

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/HazelcastStateService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/HazelcastStateService.java
@@ -10,9 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * The HazelcastStateService manages the current pointer of the Hazelcast import process.
- *
+ * <p>
  * That pointer is required to read the next-relevant message from the RingBuffer
- *
+ * <p>
  * Usually, that RingBuffer is read 1 by 1, but sometimes, the RingBuffer may overrun by the export process,
  * and in that case, the Import process will set the sequence to the current position of the RingBuffer.
  */

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/IncidentProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/IncidentProtobufImporter.java
@@ -17,7 +17,7 @@ public class IncidentProtobufImporter {
   private final Counter resolvedCounter;
 
   @Autowired
-  public IncidentHazelcastImporter(IncidentRepository incidentRepository, MeterRegistry meterRegistry) {
+  public IncidentProtobufImporter(IncidentRepository incidentRepository, MeterRegistry meterRegistry) {
     this.incidentRepository = incidentRepository;
 
     createdCounter = Counter.builder("zeebemonitor_importer_incident").tag("action", "created").description("number of processed incidents").register(meterRegistry);

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/IncidentProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/IncidentProtobufImporter.java
@@ -1,6 +1,8 @@
 package io.zeebe.monitor.zeebe.protobuf.importers;
 
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.IncidentEntity;
 import io.zeebe.monitor.repository.IncidentRepository;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class IncidentProtobufImporter {
 
   @Autowired private IncidentRepository incidentRepository;
+  @Autowired private MeterRegistry meterRegistry;
 
   public void importIncident(final Schema.IncidentRecord record) {
 
@@ -39,9 +42,13 @@ public class IncidentProtobufImporter {
       entity.setCreated(timestamp);
       incidentRepository.save(entity);
 
+      Counter.builder("zeebemonitor_importer_incident").tag("action", "created").description("number of processed incidents").register(meterRegistry).increment();
+
     } else if (intent == IncidentIntent.RESOLVED) {
       entity.setResolved(timestamp);
       incidentRepository.save(entity);
+
+      Counter.builder("zeebemonitor_importer_incident").tag("action", "resolved").description("number of processed incidents").register(meterRegistry).increment();
     }
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
@@ -1,6 +1,8 @@
 package io.zeebe.monitor.zeebe.protobuf.importers;
 
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.JobEntity;
 import io.zeebe.monitor.repository.JobRepository;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class JobProtobufImporter {
 
   @Autowired private JobRepository jobRepository;
+  @Autowired private MeterRegistry meterRegistry;
 
   public void importJob(final Schema.JobRecord record) {
 
@@ -36,5 +39,7 @@ public class JobProtobufImporter {
     entity.setWorker(record.getWorker());
     entity.setRetries(record.getRetries());
     jobRepository.save(entity);
+
+    Counter.builder("zeebemonitor_importer_job").tag("action", "imported").tag("state", entity.getState()).description("number of processed jobs").register(meterRegistry).increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
@@ -19,7 +19,7 @@ public class JobProtobufImporter {
   public JobProtobufImporter(JobRepository jobRepository, MeterRegistry meterRegistry) {
     this.jobRepository = jobRepository;
 
-    counter = Counter.builder("zeebemonitor_importer_job").description("number of processed jobs").register(meterRegistry);
+    this.counter = Counter.builder("zeebemonitor_importer_job").description("number of processed jobs").register(meterRegistry);
   }
 
   public void importJob(final Schema.JobRecord record) {

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
@@ -12,8 +12,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class JobProtobufImporter {
 
-  @Autowired private JobRepository jobRepository;
-  @Autowired private MeterRegistry meterRegistry;
+  private final JobRepository jobRepository;
+  private final Counter counter;
+
+  public JobHazelcastImporter(JobRepository jobRepository, MeterRegistry meterRegistry) {
+    this.jobRepository = jobRepository;
+
+    counter = Counter.builder("zeebemonitor_importer_job").description("number of processed jobs").register(meterRegistry);
+  }
 
   public void importJob(final Schema.JobRecord record) {
 
@@ -40,6 +46,6 @@ public class JobProtobufImporter {
     entity.setRetries(record.getRetries());
     jobRepository.save(entity);
 
-    Counter.builder("zeebemonitor_importer_job").tag("action", "imported").tag("state", entity.getState()).description("number of processed jobs").register(meterRegistry).increment();
+    counter.increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
@@ -16,7 +16,7 @@ public class JobProtobufImporter {
   private final Counter counter;
 
   @Autowired
-  public JobHazelcastImporter(JobRepository jobRepository, MeterRegistry meterRegistry) {
+  public JobProtobufImporter(JobRepository jobRepository, MeterRegistry meterRegistry) {
     this.jobRepository = jobRepository;
 
     counter = Counter.builder("zeebemonitor_importer_job").description("number of processed jobs").register(meterRegistry);

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/JobProtobufImporter.java
@@ -15,6 +15,7 @@ public class JobProtobufImporter {
   private final JobRepository jobRepository;
   private final Counter counter;
 
+  @Autowired
   public JobHazelcastImporter(JobRepository jobRepository, MeterRegistry meterRegistry) {
     this.jobRepository = jobRepository;
 

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageProtobufImporter.java
@@ -12,8 +12,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class MessageProtobufImporter {
 
-  @Autowired private MessageRepository messageRepository;
-  @Autowired private MeterRegistry meterRegistry;
+  private final MessageRepository messageRepository;
+  private final Counter counter;
+
+  @Autowired
+  public MessageHazelcastImporter(MessageRepository messageRepository, MeterRegistry meterRegistry) {
+    this.messageRepository = messageRepository;
+
+    this.counter = Counter.builder("zeebemonitor_importer_message").description("number of processed messages").register(meterRegistry);
+  }
 
   public void importMessage(final Schema.MessageRecord record) {
 
@@ -39,6 +46,6 @@ public class MessageProtobufImporter {
     entity.setTimestamp(timestamp);
     messageRepository.save(entity);
 
-    Counter.builder("zeebemonitor_importer_message").tag("action", "imported").tag("state", intent.name().toLowerCase()).description("number of processed messages").register(meterRegistry).increment();
+    counter.increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageProtobufImporter.java
@@ -1,6 +1,8 @@
 package io.zeebe.monitor.zeebe.protobuf.importers;
 
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.MessageEntity;
 import io.zeebe.monitor.repository.MessageRepository;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class MessageProtobufImporter {
 
   @Autowired private MessageRepository messageRepository;
+  @Autowired private MeterRegistry meterRegistry;
 
   public void importMessage(final Schema.MessageRecord record) {
 
@@ -35,5 +38,7 @@ public class MessageProtobufImporter {
     entity.setState(intent.name().toLowerCase());
     entity.setTimestamp(timestamp);
     messageRepository.save(entity);
+
+    Counter.builder("zeebemonitor_importer_message").tag("action", "imported").tag("state", intent.name().toLowerCase()).description("number of processed messages").register(meterRegistry).increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageProtobufImporter.java
@@ -16,7 +16,7 @@ public class MessageProtobufImporter {
   private final Counter counter;
 
   @Autowired
-  public MessageHazelcastImporter(MessageRepository messageRepository, MeterRegistry meterRegistry) {
+  public MessageProtobufImporter(MessageRepository messageRepository, MeterRegistry meterRegistry) {
     this.messageRepository = messageRepository;
 
     this.counter = Counter.builder("zeebemonitor_importer_message").description("number of processed messages").register(meterRegistry);

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageSubscriptionProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageSubscriptionProtobufImporter.java
@@ -18,6 +18,7 @@ public class MessageSubscriptionProtobufImporter {
   private final Counter subsCounter;
   private final Counter eventCounter;
 
+  @Autowired
   public MessageSubscriptionHazelcastImporter(MessageSubscriptionRepository messageSubscriptionRepository, MeterRegistry meterRegistry) {
     this.messageSubscriptionRepository = messageSubscriptionRepository;
 

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageSubscriptionProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageSubscriptionProtobufImporter.java
@@ -19,7 +19,7 @@ public class MessageSubscriptionProtobufImporter {
   private final Counter eventCounter;
 
   @Autowired
-  public MessageSubscriptionHazelcastImporter(MessageSubscriptionRepository messageSubscriptionRepository, MeterRegistry meterRegistry) {
+  public MessageSubscriptionProtobufImporter(MessageSubscriptionRepository messageSubscriptionRepository, MeterRegistry meterRegistry) {
     this.messageSubscriptionRepository = messageSubscriptionRepository;
 
     this.subsCounter =

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageSubscriptionProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/MessageSubscriptionProtobufImporter.java
@@ -2,6 +2,8 @@ package io.zeebe.monitor.zeebe.protobuf.importers;
 
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.MessageSubscriptionEntity;
 import io.zeebe.monitor.repository.MessageSubscriptionRepository;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class MessageSubscriptionProtobufImporter {
 
   @Autowired private MessageSubscriptionRepository messageSubscriptionRepository;
+  @Autowired private MeterRegistry meterRegistry;
 
   public void importMessageSubscription(final Schema.MessageSubscriptionRecord record) {
 
@@ -39,6 +42,8 @@ public class MessageSubscriptionProtobufImporter {
     entity.setState(intent.name().toLowerCase());
     entity.setTimestamp(timestamp);
     messageSubscriptionRepository.save(entity);
+
+    Counter.builder("zeebemonitor_importer_message_subscription").tag("action", "imported").tag("state", entity.getState()).description("number of processed message subscriptions").register(meterRegistry).increment();
   }
 
   public void importMessageStartEventSubscription(
@@ -66,6 +71,8 @@ public class MessageSubscriptionProtobufImporter {
     entity.setState(intent.name().toLowerCase());
     entity.setTimestamp(timestamp);
     messageSubscriptionRepository.save(entity);
+
+    Counter.builder("zeebemonitor_importer_message_subscription").tag("action", "imported").tag("state", entity.getState()).description("number of processed message start events").register(meterRegistry).increment();
   }
 
   private String generateId() {

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ProcessAndElementProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ProcessAndElementProtobufImporter.java
@@ -92,7 +92,8 @@ public class ProcessAndElementProtobufImporter {
       entity.setStart(timestamp);
       processInstanceRepository.save(entity);
 
-      notificationService.sendCreatedProcessInstance(record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+      notificationService.sendCreatedProcessInstance(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
 
       instanceActivatedCounter.increment();
 
@@ -101,7 +102,8 @@ public class ProcessAndElementProtobufImporter {
       entity.setEnd(timestamp);
       processInstanceRepository.save(entity);
 
-      notificationService.sendEndedProcessInstance(record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+      notificationService.sendEndedProcessInstance(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
 
       instanceCompletedCounter.increment();
 
@@ -110,7 +112,8 @@ public class ProcessAndElementProtobufImporter {
       entity.setEnd(timestamp);
       processInstanceRepository.save(entity);
 
-      notificationService.sendEndedProcessInstance(record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+      notificationService.sendEndedProcessInstance(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
 
       instanceTerminatedCounter.increment();
     }
@@ -130,7 +133,8 @@ public class ProcessAndElementProtobufImporter {
       entity.setProcessDefinitionKey(record.getProcessDefinitionKey());
       entity.setBpmnElementType(record.getBpmnElementType());
       elementInstanceRepository.save(entity);
-      notificationService.sendUpdatedProcessInstance(record.getProcessInstanceKey(), record.getProcessDefinitionKey());
+      notificationService.sendUpdatedProcessInstance(
+          record.getProcessInstanceKey(), record.getProcessDefinitionKey());
 
       elementInstanceCounter.increment();
     }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ProcessAndElementProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/ProcessAndElementProtobufImporter.java
@@ -30,7 +30,7 @@ public class ProcessAndElementProtobufImporter {
   private final Counter elementInstanceCounter;
 
   @Autowired
-  public ProcessAndElementHazelcastImporter(ProcessRepository processRepository, ProcessInstanceRepository processInstanceRepository, ElementInstanceRepository elementInstanceRepository, MeterRegistry meterRegistry, ZeebeNotificationService notificationService) {
+  public ProcessAndElementProtobufImporter(ProcessRepository processRepository, ProcessInstanceRepository processInstanceRepository, ElementInstanceRepository elementInstanceRepository, MeterRegistry meterRegistry, ZeebeNotificationService notificationService) {
     this.processRepository = processRepository;
     this.processInstanceRepository = processInstanceRepository;
     this.elementInstanceRepository = elementInstanceRepository;

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
@@ -16,7 +16,7 @@ public class TimerProtobufImporter {
   private final Counter timerCounter;
 
   @Autowired
-  public TimerHazelcastImporter(TimerRepository timerRepository, MeterRegistry meterRegistry) {
+  public TimerProtobufImporter(TimerRepository timerRepository, MeterRegistry meterRegistry) {
     this.timerRepository = timerRepository;
 
     this.timerCounter = Counter.builder("zeebemonitor_importer_timer").description("number of processed timers").register(meterRegistry);

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
@@ -15,6 +15,7 @@ public class TimerProtobufImporter {
   private final TimerRepository timerRepository;
   private final Counter timerCounter;
 
+  @Autowired
   public TimerHazelcastImporter(TimerRepository timerRepository, MeterRegistry meterRegistry) {
     this.timerRepository = timerRepository;
 

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
@@ -12,8 +12,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class TimerProtobufImporter {
 
-  @Autowired private TimerRepository timerRepository;
-  @Autowired private MeterRegistry meterRegistry;
+  private final TimerRepository timerRepository;
+  private final Counter timerCounter;
+
+  public TimerHazelcastImporter(TimerRepository timerRepository, MeterRegistry meterRegistry) {
+    this.timerRepository = timerRepository;
+
+    this.timerCounter = Counter.builder("zeebemonitor_importer_timer").description("number of processed timers").register(meterRegistry);
+  }
 
   public void importTimer(final Schema.TimerRecord record) {
 
@@ -45,6 +51,6 @@ public class TimerProtobufImporter {
     entity.setTimestamp(timestamp);
     timerRepository.save(entity);
 
-    Counter.builder("zeebemonitor_importer_timer").tag("action", "imported").tag("state", entity.getState()).description("number of processed timers").register(meterRegistry).increment();
+    timerCounter.increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/TimerProtobufImporter.java
@@ -1,6 +1,8 @@
 package io.zeebe.monitor.zeebe.protobuf.importers;
 
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.TimerEntity;
 import io.zeebe.monitor.repository.TimerRepository;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class TimerProtobufImporter {
 
   @Autowired private TimerRepository timerRepository;
+  @Autowired private MeterRegistry meterRegistry;
 
   public void importTimer(final Schema.TimerRecord record) {
 
@@ -41,5 +44,7 @@ public class TimerProtobufImporter {
     entity.setState(intent.name().toLowerCase());
     entity.setTimestamp(timestamp);
     timerRepository.save(entity);
+
+    Counter.builder("zeebemonitor_importer_timer").tag("action", "imported").tag("state", entity.getState()).description("number of processed timers").register(meterRegistry).increment();
   }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/VariableProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/VariableProtobufImporter.java
@@ -16,7 +16,7 @@ public class VariableProtobufImporter {
   private final Counter variableUpdatedCounter;
 
   @Autowired
-  public VariableHazelcastImporter(VariableRepository variableRepository, MeterRegistry meterRegistry) {
+  public VariableProtobufImporter(VariableRepository variableRepository, MeterRegistry meterRegistry) {
     this.variableRepository = variableRepository;
 
     this.variableCreatedCounter = Counter.builder("zeebemonitor_importer_variable").tag("action", "imported").description("number of processed variables").register(meterRegistry);

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/VariableProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/VariableProtobufImporter.java
@@ -15,6 +15,7 @@ public class VariableProtobufImporter {
   private final Counter variableCreatedCounter;
   private final Counter variableUpdatedCounter;
 
+  @Autowired
   public VariableHazelcastImporter(VariableRepository variableRepository, MeterRegistry meterRegistry) {
     this.variableRepository = variableRepository;
 

--- a/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/VariableProtobufImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/protobuf/importers/VariableProtobufImporter.java
@@ -1,5 +1,7 @@
 package io.zeebe.monitor.zeebe.protobuf.importers;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.VariableEntity;
 import io.zeebe.monitor.repository.VariableRepository;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class VariableProtobufImporter {
 
   @Autowired private VariableRepository variableRepository;
+  @Autowired private MeterRegistry meterRegistry;
 
   public void importVariable(final Schema.VariableRecord record) {
     final VariableEntity newVariable = new VariableEntity();
@@ -23,6 +26,8 @@ public class VariableProtobufImporter {
       newVariable.setScopeKey(record.getScopeKey());
       newVariable.setState(record.getMetadata().getIntent().toLowerCase());
       variableRepository.save(newVariable);
+
+      Counter.builder("zeebemonitor_importer_variable").tag("action", "imported").tag("state", newVariable.getState()).description("number of processed variables").register(meterRegistry).increment();
     }
   }
 }

--- a/src/test/java/io/zeebe/monitor/repository/TestContextJpaConfiguration.java
+++ b/src/test/java/io/zeebe/monitor/repository/TestContextJpaConfiguration.java
@@ -1,5 +1,7 @@
 package io.zeebe.monitor.repository;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +50,11 @@ public class TestContextJpaConfiguration {
     JpaTransactionManager transactionManager = new JpaTransactionManager();
     transactionManager.setEntityManagerFactory(entityManagerFactory.getObject());
     return transactionManager;
+  }
+
+  @Bean
+  public MeterRegistry meterRegistry() {
+    return new SimpleMeterRegistry();
   }
 
   private Properties getAdditionalJpaProperties() {


### PR DESCRIPTION
This PR introduces some metrics about the import process.

These are collected when:
- items are stored in the database
- when reading from Hazelcast's RingBuffer.

In addition, it replaces field-based autowiring with the recommended constructor autowiring.