### PR TITLE
Search processes by their BPMN ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
         <!-- pin Hazelcast version because of spring-boot-dependencies -->
         <version.hazelcast>5.3.6</version.hazelcast>
 
+        <version.hibernate.validator>8.0.1.Final</version.hibernate.validator>
+
         <!-- release parent settings -->
         <version.java>17</version.java>
         <java.version>${version.java}</java.version>
@@ -196,6 +198,12 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${version.hibernate.validator}</version>
         </dependency>
 
         <!-- js libs -->

--- a/src/main/java/io/zeebe/monitor/entity/ProcessEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/ProcessEntity.java
@@ -19,6 +19,9 @@ import jakarta.persistence.*;
 import org.hibernate.Length;
 
 @Entity(name = "PROCESS")
+@Table(indexes = {
+        @Index(name = "process_bpmnProcessId", columnList = "BPMN_PROCESS_ID_"),
+})
 public class ProcessEntity {
   @Id
   @Column(name = "KEY_")

--- a/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
@@ -20,10 +20,12 @@ import io.zeebe.monitor.entity.ProcessEntity;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ProcessRepository extends PagingAndSortingRepository<ProcessEntity, Long>, CrudRepository<ProcessEntity, Long> {
 
@@ -41,5 +43,6 @@ public interface ProcessRepository extends PagingAndSortingRepository<ProcessEnt
       @Param("intents") Collection<String> intents,
       @Param("excludeElementTypes") Collection<String> excludeElementTypes);
 
+  @Transactional(readOnly = true)
   List<ProcessEntity> findByBpmnProcessIdStartsWith(String bpmnProcessId);
 }

--- a/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
@@ -40,4 +40,6 @@ public interface ProcessRepository extends PagingAndSortingRepository<ProcessEnt
       @Param("key") long key,
       @Param("intents") Collection<String> intents,
       @Param("excludeElementTypes") Collection<String> excludeElementTypes);
+
+  List<ProcessEntity> findByBpmnProcessIdStartsWith(String bpmnProcessId);
 }

--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -72,6 +72,8 @@ public class ProcessesViewController extends AbstractViewController {
       }
 
       model.put("processes", processes);
+      model.put("bpmnProcessId", bpmnProcessId.get());
+      model.put("count", processes.size());
 
       addPaginationToModel(model, Pageable.ofSize(Integer.MAX_VALUE), processes.size());
       addDefaultAttributesToModel(model);
@@ -85,6 +87,7 @@ public class ProcessesViewController extends AbstractViewController {
       }
 
       model.put("processes", processes);
+      model.remove("bpmnProcessId");
       model.put("count", count);
 
       addPaginationToModel(model, pageable, count);

--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import jakarta.validation.constraints.Size;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -62,7 +63,7 @@ public class ProcessesViewController extends AbstractViewController {
   }
 
   @GetMapping("/views/processes")
-  public String processList(final Map<String, Object> model, final Pageable pageable, @RequestParam("bpmnProcessId") Optional<String> bpmnProcessId) {
+  public String processList(final Map<String, Object> model, final Pageable pageable, @RequestParam("bpmnProcessId") Optional<@Size(min = 3) String> bpmnProcessId) {
 
     if (bpmnProcessId.isPresent()) {
       final List<ProcessDto> processes = new ArrayList<>();

--- a/src/main/resources/templates/process-list-view.html
+++ b/src/main/resources/templates/process-list-view.html
@@ -13,7 +13,7 @@
             <label for="bpmn-search-input">
                     Search by BPMN Process ID
             </label>
-            <input id="bpmn-search-input" placeholder="BPMN process id" name="bpmnProcessId" type="text" title="Type in a bpmnId" />
+            <input id="bpmn-search-input" placeholder="BPMN process id" name="bpmnProcessId" type="text" title="Type in a bpmnId" minlength="3" />
             <button type="submit">Search</button>
         </form>
 

--- a/src/main/resources/templates/process-list-view.html
+++ b/src/main/resources/templates/process-list-view.html
@@ -25,6 +25,7 @@
 
         <table class="table table-striped">
             <thead>
+            <tr>
             <th>Process Definition Key</th>
             <th>BPMN process id</th>
             <th>Version</th>
@@ -36,6 +37,7 @@
                     <svg class="bi" width="12" height="12" fill="white"><use xlink:href="/img/bootstrap-icons.svg#caret-up-fill"/></svg>
                 </a>
             </th>
+            </tr>
             </thead>
 
             {{#processes}}

--- a/src/main/resources/templates/process-list-view.html
+++ b/src/main/resources/templates/process-list-view.html
@@ -9,6 +9,14 @@
             New Deployment
         </button>
 
+        <form method="get" action="{{context-path}}views/processes">
+            <label for="bpmn-search-input">
+                    Search by BPMN Process ID
+            </label>
+            <input id="bpmn-search-input" placeholder="BPMN process id" name="bpmnProcessId" type="text" title="Type in a bpmnId" />
+            <button type="submit">Search</button>
+        </form>
+
     </div>
 
     <div class="col-md-12">


### PR DESCRIPTION
This PR introduces a simple server-side search by BPMN Process ID to the processes view.

When searching, no pagination is provided, to simplify the implementation of the query and the count a bit.