### PR TITLE
fix: ghcr.io/.../zeebe-simple-monitor:2.7.1 does not exist

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -136,7 +136,7 @@ services:
 
   simple-monitor-in-memory-redis:
     container_name: zeebe-simple-monitor-in-memory-redis
-    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.7.1
+    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.7.2
     environment:
       - zeebe.client.broker.gateway-address=zeebe:26500
       - zeebe-importer=redis


### PR DESCRIPTION
The docker compose file does not work, because the image
ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.7.1
does not exist in ghcr.io