### PR TITLE
[GH-737] feat: adds a link to the latest version of process definition in deta…

### DIFF
--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -30,10 +30,7 @@ import io.zeebe.monitor.rest.dto.TimerDto;
 import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -113,8 +110,11 @@ public class ProcessesViewController extends AbstractViewController {
             .findByKey(key)
             .orElseThrow(
                 () -> new ResponseStatusException(NOT_FOUND, "No process found with key: " + key));
-
     model.put("process", toDto(process));
+
+    final Optional<ProcessEntity> latest = processRepository.findByBpmnProcessIdStartsWith(process.getBpmnProcessId())
+            .stream().max(Comparator.comparingInt(ProcessEntity::getVersion));
+    model.put("latestProcessDefinition", toDto(latest.orElse(process)));
     model.put("resource", getProcessResource(process));
 
     final List<ElementInstanceState> elementInstanceStates = getElementInstanceStates(key);

--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -112,8 +112,9 @@ public class ProcessesViewController extends AbstractViewController {
                 () -> new ResponseStatusException(NOT_FOUND, "No process found with key: " + key));
     model.put("process", toDto(process));
 
-    final Optional<ProcessEntity> latest = processRepository.findByBpmnProcessIdStartsWith(process.getBpmnProcessId())
-            .stream().max(Comparator.comparingInt(ProcessEntity::getVersion));
+    final Optional<ProcessEntity> latest =
+        processRepository.findByBpmnProcessIdStartsWith(process.getBpmnProcessId()).stream()
+            .max(Comparator.comparingInt(ProcessEntity::getVersion));
     model.put("latestProcessDefinition", toDto(latest.orElse(process)));
     model.put("resource", getProcessResource(process));
 

--- a/src/main/resources/templates/process-detail-view.html
+++ b/src/main/resources/templates/process-detail-view.html
@@ -26,6 +26,10 @@
                 <td>{{bpmnProcessId}}</td>
             </tr>
             <tr>
+                <th>Latest Version</th>
+                <td><a href="{{context-path}}views/processes/{{latestProcessDefinition.processDefinitionKey}}">{{latestProcessDefinition.version}}</a></td>
+            </tr>
+            <tr>
                 <th>Version</th>
                 <td>{{version}}</td>
             </tr>


### PR DESCRIPTION
### PR Description

https://github.com/camunda-community-hub/zeebe-simple-monitor/issues/737

Looking at the code again, I felt it was more natural to enhance the process detail view rather than add another column to the process list view.

### Before creating a PR, please ensure...

- [x] the code is proper formatted (e.g. running `mvn com.spotify.fmt:fmt-maven-plugin:2.25:format`)
- [ ] your code contribution contains new unit tests (if applicable)
- [x] the tests are alle 'green'
- [x] the documentation is updated (if applicable)

### Visual Verification

Visit an older version

<img width="522" alt="image" src="https://github.com/user-attachments/assets/abe290c1-61b9-4540-9395-1f5b295d2224" />

and then visit that to get to the latest

<img width="520" alt="image" src="https://github.com/user-attachments/assets/dec8bdfc-1ca6-4bbb-b4c7-61d4646cae4a" />

