### PR TITLE
feat(ui): show only latest processes in main page

### DIFF
--- a/src/main/java/io/zeebe/monitor/querydsl/ProcessEntityPredicatesBuilder.java
+++ b/src/main/java/io/zeebe/monitor/querydsl/ProcessEntityPredicatesBuilder.java
@@ -1,0 +1,43 @@
+package io.zeebe.monitor.querydsl;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.PathBuilder;
+import io.zeebe.monitor.entity.QProcessEntity;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.util.CollectionUtils;
+
+public class ProcessEntityPredicatesBuilder {
+
+  final PathBuilder<QProcessEntity> pathBuilder =
+      new PathBuilder<>(QProcessEntity.class, QProcessEntity.processEntity.getMetadata());
+
+  private final List<Predicate> predicates = new ArrayList<>();
+
+  public ProcessEntityPredicatesBuilder withBpmnProcessIdPrefix(String processId) {
+    if (!isEmpty(processId)) {
+      predicates.add(pathBuilder.getString("bpmnProcessId").startsWithIgnoreCase(processId));
+    }
+    return this;
+  }
+
+  public ProcessEntityPredicatesBuilder withKeys(Collection<Long> keys) {
+    if (!CollectionUtils.isEmpty(keys)) {
+      predicates.add(pathBuilder.getNumber("key", Long.class).in(keys));
+    }
+    return this;
+  }
+
+  public Predicate build() {
+    BooleanExpression result = Expressions.asBoolean(true).isTrue();
+    for (Predicate predicate : predicates) {
+      result = result.and(predicate);
+    }
+    return result;
+  }
+}

--- a/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
@@ -21,13 +21,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface ProcessRepository
-    extends PagingAndSortingRepository<ProcessEntity, Long>, CrudRepository<ProcessEntity, Long> {
+    extends PagingAndSortingRepository<ProcessEntity, Long>,
+        QuerydslPredicateExecutor<ProcessEntity>,
+        CrudRepository<ProcessEntity, Long> {
 
   Optional<ProcessEntity> findByKey(long key);
 
@@ -43,6 +45,13 @@ public interface ProcessRepository
       @Param("intents") Collection<String> intents,
       @Param("excludeElementTypes") Collection<String> excludeElementTypes);
 
-  @Transactional(readOnly = true)
-  List<ProcessEntity> findByBpmnProcessIdStartsWith(String bpmnProcessId);
+  @Query(
+      nativeQuery = true,
+      value =
+          """
+                  SELECT p.key_
+                      FROM process p WHERE (bpmn_process_id_,version_) IN
+                         (SELECT bpmn_process_id_, MAX(version_)  FROM process p  GROUP BY p.bpmn_process_id_)
+                  """)
+  List<Long> findLatestVersions();
 }

--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -17,6 +17,7 @@ import io.zeebe.monitor.entity.MessageSubscriptionEntity;
 import io.zeebe.monitor.entity.ProcessEntity;
 import io.zeebe.monitor.entity.ProcessInstanceEntity;
 import io.zeebe.monitor.entity.TimerEntity;
+import io.zeebe.monitor.querydsl.ProcessEntityPredicatesBuilder;
 import io.zeebe.monitor.repository.MessageSubscriptionRepository;
 import io.zeebe.monitor.repository.ProcessInstanceRepository;
 import io.zeebe.monitor.repository.ProcessRepository;
@@ -30,14 +31,13 @@ import io.zeebe.monitor.rest.dto.TimerDto;
 import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -51,52 +51,59 @@ public class ProcessesViewController extends AbstractViewController {
   static final List<String> EXCLUDE_ELEMENT_TYPES =
       List.of(BpmnElementType.MULTI_INSTANCE_BODY.name());
 
+  static final Sort DEFAULT_SORT =
+      Sort.by(Sort.Order.desc("bpmnProcessId"), Sort.Order.desc("timestamp"));
+
   @Autowired private ProcessRepository processRepository;
   @Autowired private ProcessInstanceRepository processInstanceRepository;
   @Autowired private MessageSubscriptionRepository messageSubscriptionRepository;
   @Autowired private TimerRepository timerRepository;
 
   @GetMapping("/")
+  @Transactional
   public String index(final Map<String, Object> model, final Pageable pageable) {
-    return processList(model, pageable, Optional.empty());
+    return processList(model, pageable, Optional.empty(), true);
   }
 
   @GetMapping("/views/processes")
+  @Transactional
   public String processList(
       final Map<String, Object> model,
-      final Pageable pageable,
-      @RequestParam(value = "bpmnProcessId", required = false) Optional<String> bpmnProcessId) {
-
-    if (bpmnProcessId.isPresent() && bpmnProcessId.get().length() >= 3) {
-      final List<ProcessDto> processes = new ArrayList<>();
-      for (final ProcessEntity processEntity :
-          processRepository.findByBpmnProcessIdStartsWith(bpmnProcessId.get())) {
-        final ProcessDto dto = toDto(processEntity);
-        processes.add(dto);
-      }
-
-      model.put("processes", processes);
-      model.put("bpmnProcessId", bpmnProcessId.get());
-      model.put("count", processes.size());
-
-      addPaginationToModel(model, Pageable.ofSize(Integer.MAX_VALUE), processes.size());
-      addDefaultAttributesToModel(model);
-    } else {
-      final long count = processRepository.count();
-
-      final List<ProcessDto> processes = new ArrayList<>();
-      for (final ProcessEntity processEntity : processRepository.findAll(pageable)) {
-        final ProcessDto dto = toDto(processEntity);
-        processes.add(dto);
-      }
-
-      model.put("processes", processes);
-      model.put("bpmnProcessId", "");
-      model.put("count", count);
-
-      addPaginationToModel(model, pageable, count);
-      addDefaultAttributesToModel(model);
+      Pageable pageable,
+      @RequestParam(value = "bpmnProcessId", required = false) Optional<String> bpmnProcessId,
+      @RequestParam(value = "latestDefinition", defaultValue = "false") boolean latestDefinition) {
+    if (!pageable.getSort().isSorted()) {
+      pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), DEFAULT_SORT);
     }
+
+    var predicatesBuilder = new ProcessEntityPredicatesBuilder();
+    bpmnProcessId
+        .filter(it -> it.length() >= 3)
+        .ifPresent(predicatesBuilder::withBpmnProcessIdPrefix);
+
+    if (latestDefinition) {
+      var latestProcessKeys = processRepository.findLatestVersions();
+      predicatesBuilder.withKeys(latestProcessKeys);
+    }
+    var processesEntities = processRepository.findAll(predicatesBuilder.build(), pageable);
+
+    final List<ProcessDto> processes = new ArrayList<>();
+
+    processesEntities.forEach(
+        process -> {
+          final ProcessDto dto = toDto(process);
+          processes.add(dto);
+        });
+
+    var totalProcesses = processesEntities.getTotalElements();
+
+    model.put("processes", processes);
+    model.put("bpmnProcessId", bpmnProcessId.orElse(""));
+    model.put("latestDefinition", latestDefinition);
+    model.put("count", totalProcesses);
+
+    addPaginationToModel(model, pageable, totalProcesses);
+    addDefaultAttributesToModel(model);
 
     return "process-list-view";
   }

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -32,7 +32,7 @@
     <div class="collapse navbar-collapse">
         <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-                <a class="nav-link" href="{{context-path}}views/processes">Processes</a>
+                <a class="nav-link" href="{{context-path}}views/processes?latestDefinition=on">Processes</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{context-path}}views/instances">Instances</a>

--- a/src/main/resources/templates/process-list-view.html
+++ b/src/main/resources/templates/process-list-view.html
@@ -9,12 +9,20 @@
             New Deployment
         </button>
 
-        <form class="form-inline" method="get" action="{{context-path}}views/processes">
-            <div class="form-group mb-2 col-sm-3">
-                <label class="mx-sm-2" for="bpmn-search-input" >Search by</label>
-                <input class="col-sm-9 form-control" id="bpmn-search-input" placeholder="BPMN process id (min 3 characters)" name="bpmnProcessId" type="text" title="BPMN process id (min 3 characters)" value="{{bpmnProcessId}}" />
+        <form method="get" action="{{context-path}}views/processes">
+            <div class="form-inline">
+                <div class="form-group mb-2 col-sm-3">
+                    <label class="mx-sm-2" for="bpmn-search-input" >Search by</label>
+                    <input class="col-sm-9 form-control" id="bpmn-search-input" placeholder="BPMN process id (min 3 characters)" name="bpmnProcessId" type="text" title="BPMN process id (min 3 characters)" value="{{bpmnProcessId}}" />
+                </div>
+
+                <button class="btn btn-secondary mb-2" type="submit">Search</button>
             </div>
-            <button class="btn btn-secondary mb-2" type="submit">Search</button>
+
+            <div class="form-group mb-2 col-sm-3">
+                <label class="form-check-label mx-sm-2" for="latestDefinition" >Latest version</label>
+                <input class="mx-sm-2"  id="latestDefinition" name="latestDefinition" type="checkbox" {{#latestDefinition}}checked{{/latestDefinition}}/>
+            </div>
         </form>
     </div>
 

--- a/src/test/java/io/zeebe/monitor/repository/ProcessRepositoryTest.java
+++ b/src/test/java/io/zeebe/monitor/repository/ProcessRepositoryTest.java
@@ -1,0 +1,44 @@
+package io.zeebe.monitor.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.monitor.entity.ProcessEntity;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProcessRepositoryTest extends ZeebeRepositoryTest {
+
+  @Autowired private ProcessRepository processRepository;
+
+  @AfterEach
+  public void tearDown() {
+    processRepository.deleteAll();
+  }
+
+  @Test
+  public void when_process_exists_with_several_versions__then_loaded_only_latest() {
+    // given
+    ProcessEntity process1 = createProcess(101L, "A", 1);
+    ProcessEntity process2 = createProcess(102L, "A", 2);
+
+    // when
+    processRepository.save(process1);
+    processRepository.save(process2);
+
+    // then
+    List<Long> latestVersions = processRepository.findLatestVersions();
+    assertThat(latestVersions).containsExactlyInAnyOrder(102L);
+  }
+
+  private ProcessEntity createProcess(long key, String bpmnProcessId, int version) {
+    ProcessEntity entity = new ProcessEntity();
+    entity.setKey(key);
+    entity.setBpmnProcessId(bpmnProcessId);
+    entity.setVersion(version);
+    entity.setResource("123");
+    entity.setTimestamp(456L);
+    return entity;
+  }
+}

--- a/src/test/java/io/zeebe/monitor/rest/ProcessesViewControllerTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ProcessesViewControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.querydsl.core.types.Predicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
@@ -19,6 +20,8 @@ public class ProcessesViewControllerTest extends AbstractViewOrResourceTest {
   @BeforeEach
   public void setUp() {
     when(processRepository.findAll(any(Pageable.class))).thenReturn(Page.empty());
+    when(processRepository.findAll(any(Predicate.class), any(Pageable.class)))
+        .thenReturn(Page.empty());
     mockCLusterStatusForViews();
   }
 


### PR DESCRIPTION
### In process page can show only latest process version(#772)

>what problem you try to solve?

Processes are constantly changing and old versions are no longer relevant.
I think it is useful to have the ability to turn off the display of old versions

> what reasoning you had with this implementation? what alternative approaches exists? what are possible downsides?

I was guided by the old code and made the new logic similar to it

> how have you tested your implementation?

I ran the app locally with fake data in the DB and I tested different combinations of filters on this page and everything worked as expected.

New filters:

![main](https://github.com/user-attachments/assets/23e4ee93-0e3c-4b99-b554-4eb8a490b259)

### Before creating a PR, please ensure...

- [x] the code is proper formatted (e.g. running `mvn com.spotify.fmt:fmt-maven-plugin:2.25:format`)
- [x] your code contribution contains new unit tests (if applicable)
- [x] the tests are alle 'green'
- [x] the documentation is updated (if applicable)
