### PR TITLE
Update dependencies for Camunda 8.5 / JDK 23 v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A monitoring application for [Zeebe](https://zeebe.io). It is designed for devel
 
 * get in touch with Zeebe and workflow execution (BPMN)
 * test workflows manually
-* provide insides on how workflows are executed 
+* provide insides on how workflows are executed
 
 The application imports the data from Zeebe using the [Hazelcast exporter](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter), [Kafka exporter](https://github.com/camunda-community-hub/zeebe-kafka-exporter) or [Redis exporter](https://github.com/camunda-community-hub/zeebe-redis-exporter). It aggregates the data and stores it into a database. The data is displayed on server-side rendered HTML pages.
 
@@ -29,15 +29,15 @@ See the [upgrade instructions](UPGRADE.md).
 The docker image for the worker is published to [GitHub Packages](https://github.com/orgs/camunda-community-hub/packages/container/package/zeebe-simple-monitor).
 
 ```
-docker pull ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.8.1
+docker pull ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.9.0
 ```
 
-* ensure that a Zeebe broker is running with a [Hazelcast exporter](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter#install) (>= `1.0.0`)  
-* configure the connection to the Zeebe broker by setting `zeebe.client.broker.gateway-address` (default: `localhost:26500`) 
+* ensure that a Zeebe broker is running with a [Hazelcast exporter](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter#install) (>= `1.0.0`)
+* configure the connection to the Zeebe broker by setting `zeebe.client.broker.gateway-address` (default: `localhost:26500`)
 * configure the connection to Hazelcast by setting `zeebe.client.worker.hazelcast.connection` (default: `localhost:5701`)
 * forward the Hazelcast port to the docker container (default: `5701`)
 * if you want to set the Hazelcast clusterName then you need to adjust the Zeebe broker and the Zeebe Simple Monitor alike
-  * Hint: this is useful, e.g. when you want to adjust the ringbuffer's size in the Hazelcast cluster (the name is relevant) 
+  * Hint: this is useful, e.g. when you want to adjust the ringbuffer's size in the Hazelcast cluster (the name is relevant)
   * a) in Zeebe broker, set the environment variable `ZEEBE_HAZELCAST_CLUSTER_NAME=dev` (default: `dev`)
   * b) in Zeebe Simple Monitor, change the setting `zeebe.client.worker.hazelcast.clusterName` (default: `dev`)
 
@@ -73,13 +73,13 @@ By default, the Zeebe Simple Monitor imports Zeebe events through Hazelcast, but
 * Activate Redis by setting `zeebe-importer: redis`
 
 
-If the Zeebe broker runs on your local machine with the default configs then start the container with the following command:  
+If the Zeebe broker runs on your local machine with the default configs then start the container with the following command:
 
 ```
-docker run --network="host" ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.8.1
+docker run --network="host" ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.9.0
 ```
 
-For a local setup, the repository contains a [docker-compose file](docker/docker-compose.yml). It starts a Zeebe broker with the Hazelcast/Kafka/Redis exporter and the application. 
+For a local setup, the repository contains a [docker-compose file](docker/docker-compose.yml). It starts a Zeebe broker with the Hazelcast/Kafka/Redis exporter and the application.
 There are several Docker Compose profiles, setting by a file [.env](docker/.env), by passing multiple --profile flags or a comma-separated list for the COMPOSE_PROFILES environment variable:
 * ```docker compose --profile hazelcast --profile hazelcast_in_memory up```
 * ```COMPOSE_PROFILES=hazelcast,hazelcast_in_memory docker compose up```
@@ -112,10 +112,10 @@ docker-compose --profile postgres up
 ### Manual
 
 1. Download the latest [application JAR](https://github.com/zeebe-io/zeebe-simple-monitor/releases) _(zeebe-simple-monitor-%{VERSION}.jar
-)_
+   )_
 
 1. Start the application
-	`java -jar zeebe-simple-monitor-{VERSION}.jar`
+   `java -jar zeebe-simple-monitor-{VERSION}.jar`
 
 1. Go to http://localhost:8082
 
@@ -239,7 +239,7 @@ For example, using PostgreSQL:
 - spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 ```
 
-* the PostgreSQL database driver is already bundled 
+* the PostgreSQL database driver is already bundled
 
 See the [docker-compose file](docker/docker-compose.yml) for a sample configuration with PostgreSQL. Profiles presets: `hazelcast,hazelcast_postgres,postgres`
 
@@ -261,8 +261,8 @@ See the [docker-compose file](docker/docker-compose.yml) for a sample configurat
 #### Change the default Zeebe importer to Kafka
 
 * set the `zeebe-importer` (default: `hazelcast`) configuration property to `kafka`
-* configure the connection to Kafka by setting `spring.kafka.bootstrap-servers` (default: `localhost:9093`) 
-* configure the Kafka topic by setting `spring.kafka.template.default-topic` (default: `zeebe`) 
+* configure the connection to Kafka by setting `spring.kafka.bootstrap-servers` (default: `localhost:9093`)
+* configure the Kafka topic by setting `spring.kafka.template.default-topic` (default: `zeebe`)
 * configure custom Kafka properties if necessary:
   * `spring.kafka.custom.concurrency` (default: `3`) is the number of threads for the Kafka listener that will import events from Zeebe
   * `spring.kafka.custom.retry.intervalMs` (default: `30000`)  and `spring.kafka.custom.retry.max-attempts` (default: `3`) are the retry configurations for a retryable exception in the listener

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the [upgrade instructions](UPGRADE.md).
 The docker image for the worker is published to [GitHub Packages](https://github.com/orgs/camunda-community-hub/packages/container/package/zeebe-simple-monitor).
 
 ```
-docker pull ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.4.1
+docker pull ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.8.1
 ```
 
 * ensure that a Zeebe broker is running with a [Hazelcast exporter](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter#install) (>= `1.0.0`)  
@@ -76,7 +76,7 @@ By default, the Zeebe Simple Monitor imports Zeebe events through Hazelcast, but
 If the Zeebe broker runs on your local machine with the default configs then start the container with the following command:  
 
 ```
-docker run --network="host" ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.4.1
+docker run --network="host" ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.8.1
 ```
 
 For a local setup, the repository contains a [docker-compose file](docker/docker-compose.yml). It starts a Zeebe broker with the Hazelcast/Kafka/Redis exporter and the application. 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
   simple-monitor-in-memory:
     container_name: zeebe-simple-monitor-in-memory
-    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.5.2
+    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.9.0
     environment:
       - zeebe.client.broker.gateway-address=zeebe:26500
       - zeebe.client.worker.hazelcast.connection=zeebe:5701
@@ -119,7 +119,7 @@ services:
 
   simple-monitor-in-memory-kafka:
     container_name: zeebe-simple-monitor-in-memory-kafka
-    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.5.2
+    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.9.0
     environment:
       - zeebe.client.broker.gateway-address=zeebe:26500
       - zeebe-importer=kafka
@@ -136,7 +136,7 @@ services:
 
   simple-monitor-in-memory-redis:
     container_name: zeebe-simple-monitor-in-memory-redis
-    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.7.2
+    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.9.0
     environment:
       - zeebe.client.broker.gateway-address=zeebe:26500
       - zeebe-importer=redis
@@ -152,7 +152,7 @@ services:
 
   simple-monitor-postgres:
     container_name: zeebe-simple-monitor-postgres
-    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.5.2
+    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.9.0
     environment:
       - zeebe.client.broker.gateway-address=zeebe:26500
       - zeebe.client.worker.hazelcast.connection=zeebe:5701
@@ -188,7 +188,7 @@ services:
 
   simple-monitor-mysql:
     container_name: zeebe-simple-monitor-mysql
-    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.5.2
+    image: ghcr.io/camunda-community-hub/zeebe-simple-monitor:2.9.0
     environment:
       - zeebe.client.broker.gateway-address=zeebe:26500
       - zeebe.client.worker.hazelcast.connection=zeebe:5701

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.zeebe</groupId>
     <artifactId>zeebe-simple-monitor</artifactId>
-    <version>v2.8.1</version>
+    <version>2.8.1</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -12,14 +12,14 @@
         <artifactId>camunda-release-parent</artifactId>
         <version>3.9.1</version>
         <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <zeebe.version>8.3.4</zeebe.version>
-        <version.zeebe.spring>8.4.2</version.zeebe.spring>
+        <zeebe.version>8.5.12</zeebe.version>
+        <version.zeebe.spring>8.5.12</version.zeebe.spring>
         <hazelcast.exporter.version>1.4.0</hazelcast.exporter.version>
         <redis.exporter.version>1.0.1</redis.exporter.version>
 
@@ -39,6 +39,7 @@
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
 
         <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
         </nexus.snapshot.repository>
@@ -95,8 +96,8 @@
 
         <!-- spring deps-->
         <dependency>
-            <groupId>io.camunda.spring</groupId>
-            <artifactId>spring-boot-starter-camunda</artifactId>
+            <groupId>io.camunda</groupId>
+            <artifactId>spring-boot-starter-camunda-sdk</artifactId>
             <version>${version.zeebe.spring}</version>
             <exclusions>
                 <exclusion>
@@ -306,26 +307,25 @@
                 </plugin>
                 <!--Plugin for query-dsl-->
                 <plugin>
-                    <groupId>com.mysema.maven</groupId>
-                    <artifactId>apt-maven-plugin</artifactId>
-                    <version>1.1.3</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>process</goal>
-                            </goals>
-                            <configuration>
-                                <includes>
-                                    <include>io.zeebe.monitor.entity.**</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
                     <configuration>
-                        <outputDirectory>target/generated-sources/annotations</outputDirectory>
-                        <processors>
-                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
-                        </processors>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>com.querydsl</groupId>
+                                <artifactId>querydsl-apt</artifactId>
+                                <version>${querydsl.version}</version>
+                                <classifier>jakarta</classifier>
+                            </path>
+                            <path>
+                                <groupId>jakarta.persistence</groupId>
+                                <artifactId>jakarta.persistence-api</artifactId>
+                                <version>3.1.0</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.zeebe</groupId>
     <artifactId>zeebe-simple-monitor</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -21,11 +21,11 @@
         <zeebe.version>8.5.12</zeebe.version>
         <version.zeebe.spring>8.5.12</version.zeebe.spring>
         <hazelcast.exporter.version>1.4.0</hazelcast.exporter.version>
-        <redis.exporter.version>1.0.1</redis.exporter.version>
+        <redis.exporter.version>1.0.2</redis.exporter.version>
 
         <querydsl.version>5.1.0</querydsl.version>
 
-        <spring.boot.version>3.4.1</spring.boot.version>
+        <spring.boot.version>3.4.2</spring.boot.version>
         <!-- pin Hazelcast version because of spring-boot-dependencies -->
         <version.hazelcast>5.5.0</version.hazelcast>
 
@@ -35,7 +35,7 @@
         <version.java>17</version.java>
         <java.version>${version.java}</java.version>
 
-        <jib-maven-plugin.image>eclipse-temurin:21-jre-jammy</jib-maven-plugin.image>
+        <jib-maven-plugin.image>eclipse-temurin:23-jre</jib-maven-plugin.image>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
This PR superseeds #775 (including some updates in README and docker-compores)

---


This PR updates the dependencies to

* latest Zeebe 8.5 (explicitly not 8.6 due to the license change)
* QueryDSL:
   * The apt-maven-plugin has been archived https://github.com/querydsl/querydsl/issues/3436#issuecomment-1328637362
* Redis Exporter 1.0.1
* Spring Boot for JDK 23 compatibility
* set JRE-23 as runtime for the docker container (JIB configuration)
* Drop the v prefix from the release version

The Hazelcast setup runs locally for me, "works-on-my-machine".

The UnitTests succeed.

Unfortunately, I cannot test the Redis/Kafka integration, the docker-compose is outdated.

I did not add any new features, especially not in the Protobuf parsers. This is only a dependency update.

### Before creating a PR, please ensure...

- [x] the code is proper formatted (e.g. running `mvn com.spotify.fmt:fmt-maven-plugin:2.25:format`)
- [x] your code contribution contains new unit tests (if applicable)
- [n/a] the tests are alle 'green'
- [x] the documentation is updated (if applicable)
