### PR TITLE
fix(ui): fix sorting by start time on process detail page

### DIFF
--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -123,7 +123,8 @@ public class ProcessesViewController extends AbstractViewController {
 
     final Optional<ProcessEntity> latest =
         processRepository
-            .findByBpmnProcessIdContaining(process.getBpmnProcessId(), pageable)
+            .findByBpmnProcessIdContaining(
+                process.getBpmnProcessId(), PageRequest.of(0, Integer.MAX_VALUE))
             .stream()
             .max(Comparator.comparingInt(ProcessEntity::getVersion));
     model.put("latestProcessDefinition", toDto(latest.orElse(process)));


### PR DESCRIPTION
## Summary
- Fix `PropertyReferenceException` when sorting process instances by start time on the process detail page (`/views/processes/{key}?sort=start,desc`)
- The `Pageable` with `sort=start` was incorrectly passed to a `ProcessEntity` query that doesn't have a `start` field
- Use an unsorted `PageRequest` for the latest version lookup since it only needs `max(version)`

Closes #809

## Test plan
- [ ] Navigate to a process detail page and sort by start time (click column header or append `?sort=start,desc`)
- [ ] Verify no `PropertyReferenceException` is thrown
- [ ] Verify process instances are correctly sorted by start time