### PR TITLE
feat(ui): add configurable timezone for displayed timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,32 @@ server:
   servlet:
     context-path: /
   allowedOriginsUrls: ""
+
+monitor:
+  display:
+    timezone: UTC
 ```
+
+#### Change the Display Timezone
+
+By default, timestamps are displayed in UTC. To display timestamps in another timezone, set an
+[IANA timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), for example:
+
+```yaml
+monitor:
+  display:
+    timezone: Asia/Kolkata
+```
+
+When using Docker, the same setting can be provided as an environment variable:
+
+```shell
+MONITOR_DISPLAY_TIMEZONE=Asia/Kolkata
+```
+
+Timestamps remain stored as epoch milliseconds; this setting changes only how they are displayed.
+The rendered value uses ISO-8601 format and includes the applicable UTC offset. For example,
+`2026-08-23T12:00:00Z` is displayed as `2026-08-23T17:30:00+05:30` in `Asia/Kolkata`.
 
 #### Change the Context-Path
 

--- a/src/main/java/io/zeebe/monitor/rest/AbstractInstanceViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/AbstractInstanceViewController.java
@@ -20,7 +20,6 @@ import io.zeebe.monitor.rest.dto.ElementInstanceState;
 import io.zeebe.monitor.rest.dto.ProcessInstanceDto;
 import java.io.IOException;
 import java.io.Writer;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -101,9 +100,9 @@ public abstract class AbstractInstanceViewController extends AbstractViewControl
     final boolean isEnded = instance.getEnd() != null && instance.getEnd() > 0;
     dto.setState(instance.getState());
     dto.setRunning(!isEnded);
-    dto.setStartTime(Instant.ofEpochMilli(instance.getStart()).toString());
+    dto.setStartTime(displayTimeFormatter.format(instance.getStart()));
     if (isEnded) {
-      dto.setEndTime(Instant.ofEpochMilli(instance.getEnd()).toString());
+      dto.setEndTime(displayTimeFormatter.format(instance.getEnd()));
     }
     if (instance.getParentElementInstanceKey() > 0) {
       dto.setParentProcessInstanceKey(instance.getParentProcessInstanceKey());

--- a/src/main/java/io/zeebe/monitor/rest/AbstractViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/AbstractViewController.java
@@ -25,6 +25,7 @@ abstract class AbstractViewController {
   @Autowired private WhitelabelPropertiesMapper whitelabelPropertiesMapper;
   @Autowired private ZeebeStatusKeeper zeebeStatusKeeper;
   @Autowired private Attributes applicationAttributes;
+  @Autowired protected DisplayTimeFormatter displayTimeFormatter;
 
   protected void addPaginationToModel(
       final Map<String, Object> model, final Pageable pageable, final long count) {

--- a/src/main/java/io/zeebe/monitor/rest/DisplayTimeFormatter.java
+++ b/src/main/java/io/zeebe/monitor/rest/DisplayTimeFormatter.java
@@ -1,0 +1,36 @@
+package io.zeebe.monitor.rest;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DisplayTimeFormatter {
+
+    private static final String PROPERTY_NAME = "monitor.display.timezone";
+
+    private final DateTimeFormatter formatter;
+
+    public DisplayTimeFormatter(
+            @Value("${" + PROPERTY_NAME + ":UTC}") final String configuredTimezone) {
+        final ZoneId zoneId = resolveZoneId(configuredTimezone);
+        formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);
+    }
+
+    private static ZoneId resolveZoneId(final String configuredTimezone) {
+        try {
+            return ZoneId.of(configuredTimezone);
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException(
+                    "Invalid timezone configured for '" + PROPERTY_NAME + "': " + configuredTimezone, e);
+        }
+    }
+
+    public String format(final long epochMillis) {
+        return formatter.format(Instant.ofEpochMilli(epochMillis));
+    }
+}

--- a/src/main/java/io/zeebe/monitor/rest/ErrorsViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ErrorsViewController.java
@@ -3,7 +3,6 @@ package io.zeebe.monitor.rest;
 import io.zeebe.monitor.entity.ErrorEntity;
 import io.zeebe.monitor.repository.ErrorRepository;
 import io.zeebe.monitor.rest.dto.ErrorDto;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +23,7 @@ public class ErrorsViewController extends AbstractViewController {
 
     final List<ErrorDto> dtos = new ArrayList<>();
     for (final ErrorEntity entity : errorRepository.findAll(pageable)) {
-      final var dto = toDto(entity);
+      final var dto = toDto(entity, displayTimeFormatter);
       dtos.add(dto);
     }
 
@@ -37,13 +36,13 @@ public class ErrorsViewController extends AbstractViewController {
     return "error-list-view";
   }
 
-  static ErrorDto toDto(final ErrorEntity entity) {
+  static ErrorDto toDto(final ErrorEntity entity, final DisplayTimeFormatter displayTimeFormatter) {
     final var dto = new ErrorDto();
     dto.setPosition(entity.getPosition());
     dto.setErrorEventPosition(entity.getErrorEventPosition());
     dto.setExceptionMessage(entity.getExceptionMessage());
     dto.setStacktrace(entity.getStacktrace());
-    dto.setTimestamp(Instant.ofEpochMilli(entity.getTimestamp()).toString());
+    dto.setTimestamp(displayTimeFormatter.format(entity.getTimestamp()));
 
     if (entity.getProcessInstanceKey() > 0) {
       dto.setProcessInstanceKey(entity.getProcessInstanceKey());

--- a/src/main/java/io/zeebe/monitor/rest/IncidentsViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/IncidentsViewController.java
@@ -6,7 +6,6 @@ import io.zeebe.monitor.querydsl.IncidentEntityPredicatesBuilder;
 import io.zeebe.monitor.repository.IncidentRepository;
 import io.zeebe.monitor.rest.dto.IncidentListDto;
 import jakarta.transaction.Transactional;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,10 +71,10 @@ public class IncidentsViewController extends AbstractViewController {
 
     final boolean isResolved = incident.getResolved() != null && incident.getResolved() > 0;
 
-    dto.setCreatedTime(Instant.ofEpochMilli(incident.getCreated()).toString());
+    dto.setCreatedTime(displayTimeFormatter.format(incident.getCreated()));
 
     if (isResolved) {
-      dto.setResolvedTime(Instant.ofEpochMilli(incident.getResolved()).toString());
+      dto.setResolvedTime(displayTimeFormatter.format(incident.getResolved()));
 
       dto.setState("Resolved");
     } else {

--- a/src/main/java/io/zeebe/monitor/rest/InstancesAuditLogViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesAuditLogViewController.java
@@ -11,7 +11,6 @@ import io.zeebe.monitor.rest.dto.AuditLogEntry;
 import io.zeebe.monitor.rest.dto.ProcessInstanceDto;
 import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ public class InstancesAuditLogViewController extends AbstractInstanceViewControl
                   entry.setElementName(flowElements.getOrDefault(e.getElementId(), ""));
                   entry.setBpmnElementType(e.getBpmnElementType());
                   entry.setState(e.getIntent());
-                  entry.setTimestamp(Instant.ofEpochMilli(e.getTimestamp()).toString());
+                  entry.setTimestamp(displayTimeFormatter.format(e.getTimestamp()));
 
                   return entry;
                 })

--- a/src/main/java/io/zeebe/monitor/rest/InstancesErrorListViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesErrorListViewController.java
@@ -44,7 +44,7 @@ public class InstancesErrorListViewController extends AbstractInstanceViewContro
       ProcessInstanceDto dto) {
     final var errors =
         errorRepository.findByProcessInstanceKey(instance.getKey(), pageable).stream()
-            .map(ErrorsViewController::toDto)
+            .map(error -> ErrorsViewController.toDto(error, displayTimeFormatter))
             .collect(Collectors.toList());
     dto.setErrors(errors);
 

--- a/src/main/java/io/zeebe/monitor/rest/InstancesIncidentListViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesIncidentListViewController.java
@@ -6,7 +6,6 @@ import io.zeebe.monitor.entity.ProcessInstanceEntity;
 import io.zeebe.monitor.rest.dto.IncidentDto;
 import io.zeebe.monitor.rest.dto.ProcessInstanceDto;
 import jakarta.transaction.Transactional;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -57,9 +56,9 @@ public class InstancesIncidentListViewController extends AbstractInstanceViewCon
                   incidentDto.setErrorMessage(i.getErrorMessage());
                   final boolean isResolved = i.getResolved() != null && i.getResolved() > 0;
                   incidentDto.setResolved(isResolved);
-                  incidentDto.setCreatedTime(Instant.ofEpochMilli(i.getCreated()).toString());
+                  incidentDto.setCreatedTime(displayTimeFormatter.format(i.getCreated()));
                   if (isResolved) {
-                    incidentDto.setResolvedTime(Instant.ofEpochMilli(i.getResolved()).toString());
+                    incidentDto.setResolvedTime(displayTimeFormatter.format(i.getResolved()));
                     incidentDto.setState("Resolved");
                   } else {
                     incidentDto.setState("Created");

--- a/src/main/java/io/zeebe/monitor/rest/InstancesJobListViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesJobListViewController.java
@@ -48,7 +48,7 @@ public class InstancesJobListViewController extends AbstractInstanceViewControll
         jobRepository.findByProcessInstanceKey(instance.getKey(), pageable).stream()
             .map(
                 job -> {
-                  final JobDto jobDto = JobsViewController.toDto(job);
+                  final JobDto jobDto = JobsViewController.toDto(job, displayTimeFormatter);
                   jobDto.setElementId(
                       elementIdsForKeys.getOrDefault(job.getElementInstanceKey(), ""));
 

--- a/src/main/java/io/zeebe/monitor/rest/InstancesMessageSubscriptionListViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesMessageSubscriptionListViewController.java
@@ -47,7 +47,7 @@ public class InstancesMessageSubscriptionListViewController extends AbstractInst
             .map(
                 subscription -> {
                   final MessageSubscriptionDto subscriptionDto =
-                      ProcessesViewController.toDto(subscription);
+                      ProcessesViewController.toDto(subscription, displayTimeFormatter);
                   subscriptionDto.setElementId(
                       elementIdsForKeys.getOrDefault(subscriptionDto.getElementInstanceKey(), ""));
 

--- a/src/main/java/io/zeebe/monitor/rest/InstancesTimerListViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesTimerListViewController.java
@@ -45,7 +45,7 @@ public class InstancesTimerListViewController extends AbstractInstanceViewContro
       ProcessInstanceDto dto) {
     final List<TimerDto> timers =
         timerRepository.findByProcessInstanceKey(instance.getKey(), pageable).stream()
-            .map(ProcessesViewController::toDto)
+            .map(timer -> ProcessesViewController.toDto(timer, displayTimeFormatter))
             .collect(Collectors.toList());
     dto.setTimers(timers);
 

--- a/src/main/java/io/zeebe/monitor/rest/InstancesVariableListController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesVariableListController.java
@@ -9,7 +9,6 @@ import io.zeebe.monitor.rest.dto.ProcessInstanceDto;
 import io.zeebe.monitor.rest.dto.VariableEntry;
 import io.zeebe.monitor.rest.dto.VariableUpdateEntry;
 import jakarta.transaction.Transactional;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -73,7 +72,7 @@ public class InstancesVariableListController extends AbstractInstanceViewControl
 
           final VariableEntity lastUpdate = variables.get(variables.size() - 1);
           variableDto.setValue(lastUpdate.getValue());
-          variableDto.setTimestamp(Instant.ofEpochMilli(lastUpdate.getTimestamp()).toString());
+          variableDto.setTimestamp(displayTimeFormatter.format(lastUpdate.getTimestamp()));
 
           final List<VariableUpdateEntry> varUpdates =
               variables.stream()
@@ -81,7 +80,7 @@ public class InstancesVariableListController extends AbstractInstanceViewControl
                       v -> {
                         final VariableUpdateEntry varUpdate = new VariableUpdateEntry();
                         varUpdate.setValue(v.getValue());
-                        varUpdate.setTimestamp(Instant.ofEpochMilli(v.getTimestamp()).toString());
+                        varUpdate.setTimestamp(displayTimeFormatter.format(v.getTimestamp()));
                         return varUpdate;
                       })
                   .collect(Collectors.toList());

--- a/src/main/java/io/zeebe/monitor/rest/InstancesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/InstancesViewController.java
@@ -23,7 +23,8 @@ public class InstancesViewController extends AbstractViewController {
 
     final List<ProcessInstanceListDto> instances = new ArrayList<>();
     for (final ProcessInstanceEntity instanceEntity : processInstanceRepository.findAll(pageable)) {
-      final ProcessInstanceListDto dto = ProcessesViewController.toDto(instanceEntity);
+      final ProcessInstanceListDto dto =
+          ProcessesViewController.toDto(instanceEntity, displayTimeFormatter);
       instances.add(dto);
     }
 

--- a/src/main/java/io/zeebe/monitor/rest/JobsViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/JobsViewController.java
@@ -3,7 +3,6 @@ package io.zeebe.monitor.rest;
 import io.zeebe.monitor.entity.JobEntity;
 import io.zeebe.monitor.repository.JobRepository;
 import io.zeebe.monitor.rest.dto.JobDto;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +28,7 @@ public class JobsViewController extends AbstractViewController {
     final List<JobDto> dtos = new ArrayList<>();
     for (final JobEntity jobEntity :
         jobRepository.findByStateNotIn(JOB_COMPLETED_INTENTS, pageable)) {
-      final JobDto dto = toDto(jobEntity);
+      final JobDto dto = toDto(jobEntity, displayTimeFormatter);
       dtos.add(dto);
     }
 
@@ -42,7 +41,7 @@ public class JobsViewController extends AbstractViewController {
     return "job-list-view";
   }
 
-  static JobDto toDto(final JobEntity job) {
+  static JobDto toDto(final JobEntity job, final DisplayTimeFormatter displayTimeFormatter) {
     final JobDto dto = new JobDto();
 
     dto.setKey(job.getKey());
@@ -52,7 +51,7 @@ public class JobsViewController extends AbstractViewController {
     dto.setState(job.getState());
     dto.setRetries(job.getRetries());
     Optional.ofNullable(job.getWorker()).ifPresent(dto::setWorker);
-    dto.setTimestamp(Instant.ofEpochMilli(job.getTimestamp()).toString());
+    dto.setTimestamp(displayTimeFormatter.format(job.getTimestamp()));
 
     return dto;
   }

--- a/src/main/java/io/zeebe/monitor/rest/MessagesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/MessagesViewController.java
@@ -3,7 +3,6 @@ package io.zeebe.monitor.rest;
 import io.zeebe.monitor.entity.MessageEntity;
 import io.zeebe.monitor.repository.MessageRepository;
 import io.zeebe.monitor.rest.dto.MessageDto;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ public class MessagesViewController extends AbstractViewController {
     dto.setMessageId(message.getMessageId());
     dto.setPayload(message.getPayload());
     dto.setState(message.getState());
-    dto.setTimestamp(Instant.ofEpochMilli(message.getTimestamp()).toString());
+    dto.setTimestamp(displayTimeFormatter.format(message.getTimestamp()));
 
     return dto;
   }

--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -30,7 +30,6 @@ import io.zeebe.monitor.rest.dto.ProcessInstanceListDto;
 import io.zeebe.monitor.rest.dto.TimerDto;
 import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
-import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -138,7 +137,7 @@ public class ProcessesViewController extends AbstractViewController {
     final List<ProcessInstanceListDto> instances = new ArrayList<>();
     for (final ProcessInstanceEntity instanceEntity :
         processInstanceRepository.findByProcessDefinitionKey(key, pageable)) {
-      instances.add(toDto(instanceEntity));
+      instances.add(toDto(instanceEntity, displayTimeFormatter));
     }
 
     model.put("instances", instances);
@@ -146,7 +145,7 @@ public class ProcessesViewController extends AbstractViewController {
 
     final List<TimerDto> timers =
         timerRepository.findByProcessDefinitionKeyAndProcessInstanceKeyIsNull(key).stream()
-            .map(ProcessesViewController::toDto)
+            .map(timer -> toDto(timer, displayTimeFormatter))
             .collect(Collectors.toList());
     model.put("timers", timers);
 
@@ -154,7 +153,7 @@ public class ProcessesViewController extends AbstractViewController {
         messageSubscriptionRepository
             .findByProcessDefinitionKeyAndProcessInstanceKeyIsNull(key)
             .stream()
-            .map(ProcessesViewController::toDto)
+            .map(subscription -> toDto(subscription, displayTimeFormatter))
             .collect(Collectors.toList());
     model.put("messageSubscriptions", messageSubscriptions);
 
@@ -176,10 +175,12 @@ public class ProcessesViewController extends AbstractViewController {
     final long ended =
         processInstanceRepository.countByProcessDefinitionKeyAndEndIsNotNull(processDefinitionKey);
 
-    return ProcessDto.from(processEntity, running, ended);
+    return ProcessDto.from(
+        processEntity, running, ended, displayTimeFormatter.format(processEntity.getTimestamp()));
   }
 
-  static ProcessInstanceListDto toDto(final ProcessInstanceEntity instance) {
+  static ProcessInstanceListDto toDto(
+      final ProcessInstanceEntity instance, final DisplayTimeFormatter displayTimeFormatter) {
 
     final ProcessInstanceListDto dto = new ProcessInstanceListDto();
     dto.setProcessInstanceKey(instance.getKey());
@@ -190,22 +191,22 @@ public class ProcessesViewController extends AbstractViewController {
     final boolean isEnded = instance.getEnd() != null && instance.getEnd() > 0;
     dto.setState(instance.getState());
 
-    dto.setStartTime(Instant.ofEpochMilli(instance.getStart()).toString());
+    dto.setStartTime(displayTimeFormatter.format(instance.getStart()));
 
     if (isEnded) {
-      dto.setEndTime(Instant.ofEpochMilli(instance.getEnd()).toString());
+      dto.setEndTime(displayTimeFormatter.format(instance.getEnd()));
     }
 
     return dto;
   }
 
-  static TimerDto toDto(final TimerEntity timer) {
+  static TimerDto toDto(final TimerEntity timer, final DisplayTimeFormatter displayTimeFormatter) {
     final TimerDto dto = new TimerDto();
 
     dto.setElementId(timer.getTargetElementId());
     dto.setState(timer.getState());
-    dto.setDueDate(Instant.ofEpochMilli(timer.getDueDate()).toString());
-    dto.setTimestamp(Instant.ofEpochMilli(timer.getTimestamp()).toString());
+    dto.setDueDate(displayTimeFormatter.format(timer.getDueDate()));
+    dto.setTimestamp(displayTimeFormatter.format(timer.getTimestamp()));
     dto.setElementInstanceKey(timer.getElementInstanceKey());
 
     final int repetitions = timer.getRepetitions();
@@ -214,7 +215,9 @@ public class ProcessesViewController extends AbstractViewController {
     return dto;
   }
 
-  static MessageSubscriptionDto toDto(final MessageSubscriptionEntity subscription) {
+  static MessageSubscriptionDto toDto(
+      final MessageSubscriptionEntity subscription,
+      final DisplayTimeFormatter displayTimeFormatter) {
     final MessageSubscriptionDto dto = new MessageSubscriptionDto();
 
     dto.setKey(subscription.getId());
@@ -227,7 +230,7 @@ public class ProcessesViewController extends AbstractViewController {
     dto.setElementId(subscription.getTargetFlowNodeId());
 
     dto.setState(subscription.getState());
-    dto.setTimestamp(Instant.ofEpochMilli(subscription.getTimestamp()).toString());
+    dto.setTimestamp(displayTimeFormatter.format(subscription.getTimestamp()));
 
     dto.setOpen(subscription.getState().equalsIgnoreCase(MessageSubscriptionIntent.CREATED.name()));
 

--- a/src/main/java/io/zeebe/monitor/rest/dto/ProcessDto.java
+++ b/src/main/java/io/zeebe/monitor/rest/dto/ProcessDto.java
@@ -16,7 +16,6 @@
 package io.zeebe.monitor.rest.dto;
 
 import io.zeebe.monitor.entity.ProcessEntity;
-import java.time.Instant;
 
 public class ProcessDto {
 
@@ -30,14 +29,17 @@ public class ProcessDto {
   private long countEnded;
 
   public static ProcessDto from(
-      final ProcessEntity entity, final long countRunning, final long countEnded) {
+      final ProcessEntity entity,
+      final long countRunning,
+      final long countEnded,
+      final String deploymentTime) {
     final ProcessDto dto = new ProcessDto();
 
     dto.processDefinitionKey = entity.getKey();
     dto.bpmnProcessId = entity.getBpmnProcessId();
     dto.version = entity.getVersion();
     dto.resource = entity.getResource();
-    dto.deploymentTime = Instant.ofEpochMilli(entity.getTimestamp()).toString();
+    dto.deploymentTime = deploymentTime;
 
     dto.countRunning = countRunning;
     dto.countEnded = countEnded;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,6 +72,11 @@ server:
       force-response: true
   allowedOriginsUrls: ""
 
+monitor:
+  display:
+    # IANA timezone used to render timestamps in the UI
+    timezone: UTC
+
 logging:
   level:
     root: ERROR

--- a/src/test/java/io/zeebe/monitor/rest/DisplayTimeFormatterTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/DisplayTimeFormatterTest.java
@@ -1,0 +1,44 @@
+package io.zeebe.monitor.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class DisplayTimeFormatterTest {
+
+  @Test
+  void shouldFormatTimestampInUtc() {
+    final var formatter = new DisplayTimeFormatter("UTC");
+    final long timestamp = Instant.parse("2026-08-23T12:00:00.123Z").toEpochMilli();
+
+    assertThat(formatter.format(timestamp)).isEqualTo("2026-08-23T12:00:00.123Z");
+  }
+
+  @Test
+  void shouldFormatTimestampInConfiguredTimezone() {
+    final var formatter = new DisplayTimeFormatter("Asia/Kolkata");
+    final long timestamp = Instant.parse("2026-08-23T12:00:00Z").toEpochMilli();
+
+    assertThat(formatter.format(timestamp)).isEqualTo("2026-08-23T17:30:00+05:30");
+  }
+
+  @Test
+  void shouldApplyDaylightSavingTimeForRegionTimezone() {
+    final var formatter = new DisplayTimeFormatter("Europe/Berlin");
+    final long winterTimestamp = Instant.parse("2026-01-15T12:00:00Z").toEpochMilli();
+    final long summerTimestamp = Instant.parse("2026-07-15T12:00:00Z").toEpochMilli();
+
+    assertThat(formatter.format(winterTimestamp)).isEqualTo("2026-01-15T13:00:00+01:00");
+    assertThat(formatter.format(summerTimestamp)).isEqualTo("2026-07-15T14:00:00+02:00");
+  }
+
+  @Test
+  void shouldRejectInvalidTimezone() {
+    assertThatThrownBy(() -> new DisplayTimeFormatter("Invalid/Timezone"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("monitor.display.timezone")
+        .hasMessageContaining("Invalid/Timezone");
+  }
+}

--- a/src/test/java/io/zeebe/monitor/rest/ProcessesViewControllerTest.java
+++ b/src/test/java/io/zeebe/monitor/rest/ProcessesViewControllerTest.java
@@ -1,6 +1,7 @@
 package io.zeebe.monitor.rest;
 
 import static io.zeebe.monitor.ZeebeSimpleMonitorApp.REPLACEMENT_CHARACTER_QUESTIONMARK;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
@@ -10,12 +11,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.querydsl.core.types.Predicate;
+import io.zeebe.monitor.entity.ProcessInstanceEntity;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public class ProcessesViewControllerTest extends AbstractViewOrResourceTest {
+
+  @Autowired private DisplayTimeFormatter displayTimeFormatter;
 
   @BeforeEach
   public void setUp() {
@@ -67,5 +73,16 @@ public class ProcessesViewControllerTest extends AbstractViewOrResourceTest {
     mockMvc
         .perform(get("/views/processes"))
         .andExpect(content().string(not(containsString(REPLACEMENT_CHARACTER_QUESTIONMARK))));
+  }
+
+  @Test
+  void process_instance_uses_default_display_timezone() {
+    final long timestamp = Instant.parse("2026-08-23T12:00:00Z").toEpochMilli();
+    final var instance = new ProcessInstanceEntity();
+    instance.setStart(timestamp);
+
+    final var dto = ProcessesViewController.toDto(instance, displayTimeFormatter);
+
+    assertThat(dto.getStartTime()).isEqualTo("2026-08-23T12:00:00Z");
   }
 }


### PR DESCRIPTION
## Problem

Zeebe Simple Monitor formats displayed timestamps using
`Instant.ofEpochMilli(...).toString()`, which always displays UTC.

Changing the container timezone, JVM timezone, database timezone, or browser
timezone does not affect the rendered values.

## Proposed solution

Add a server-wide configuration property:

monitor:
  display:
    timezone: UTC

The equivalent environment variable would be:

MONITOR_DISPLAY_TIMEZONE=Asia/Kolkata

Requirements:

- Default to `UTC` to preserve existing behavior.
- Accept IANA timezone identifiers such as `Asia/Kolkata`,
  `Europe/Berlin`, and `America/New_York`.
- Continue rendering ISO-8601 timestamps, including the UTC offset.
- Apply the configuration consistently to every displayed timestamp.
- Do not modify timestamps stored in the database.
- Fail at startup with a clear error when the configured timezone is invalid.
- Document the YAML and Docker environment-variable configuration.

Example:

UTC:
2026-08-23T12:00:00Z

Asia/Kolkata:
2026-08-23T17:30:00+05:30

## Proposed implementation

Introduce a central `DisplayTimeFormatter` Spring component backed by
`ZoneId` and `DateTimeFormatter.ISO_OFFSET_DATE_TIME`.

Replace the duplicated `Instant.ofEpochMilli(...).toString()` calls in
the view/controller layer with this component.

## Testing

- Ran `mvn -q -B clean verify com.mycila:license-maven-plugin:check`
- All 29 automated tests passed
- Started the packaged application with `MONITOR_DISPLAY_TIMEZONE=Asia/Kolkata`
- Verified timestamps across all timestamp-bearing UI views
- Verified UTC default behavior, regional daylight-saving behavior, and invalid-timezone validation
- UI testing used seeded H2 data with the Zeebe importer disabled

Closes #814